### PR TITLE
fix: RWA M-05

### DIFF
--- a/packages/core-contracts/src/contracts/FleetCommanderWhitelist.sol
+++ b/packages/core-contracts/src/contracts/FleetCommanderWhitelist.sol
@@ -498,7 +498,7 @@ contract FleetCommanderWhitelist is
     function transfer(
         address to,
         uint256 amount
-    ) public override(IERC20, ERC20) returns (bool) {
+    ) public override(IERC20, ERC20) whenNotPaused returns (bool) {
         if (hasOperatorRole(_msgSender())) {
             return super.transfer(to, amount);
         }
@@ -517,7 +517,7 @@ contract FleetCommanderWhitelist is
         address from,
         address to,
         uint256 amount
-    ) public override(IERC20, ERC20) returns (bool) {
+    ) public override(IERC20, ERC20) whenNotPaused returns (bool) {
         if (hasOperatorRole(_msgSender())) {
             return super.transferFrom(from, to, amount);
         }

--- a/packages/core-contracts/test/fleets/FleetCommanderWhitelist.t.sol
+++ b/packages/core-contracts/test/fleets/FleetCommanderWhitelist.t.sol
@@ -206,4 +206,49 @@ contract FleetCommanderWhitelistTest is
         whitelistFleet.transfer(whitelistedRecipient, amountToTransfer);
         vm.stopPrank();
     }
+
+    /**
+     * @notice Test that a normal whitelisted user CANNOT transfer if the fleet is paused (M-05).
+     */
+    function test_RevertIfTransferPaused() public {
+        uint256 amountToTransfer = 10 * 10 ** 6;
+        address whitelistedRecipient = makeAddr("whitelistedRecipient");
+
+        vm.startPrank(governor);
+        whitelistFleet.setWhitelisted(whitelistedRecipient, true);
+        whitelistFleet.setFleetTokenTransferability(true); // Enable transfers
+        whitelistFleet.pause();
+        vm.stopPrank();
+
+        vm.startPrank(mockUser);
+        vm.expectRevert(abi.encodeWithSignature("EnforcedPause()"));
+        whitelistFleet.transfer(whitelistedRecipient, amountToTransfer);
+        vm.stopPrank();
+    }
+
+    /**
+     * @notice Test that a normal whitelisted user CANNOT transferFrom if the fleet is paused (M-05).
+     */
+    function test_RevertIfTransferFromPaused() public {
+        uint256 amountToTransfer = 10 * 10 ** 6;
+        address whitelistedRecipient = makeAddr("whitelistedRecipient");
+
+        vm.startPrank(mockUser);
+        whitelistFleet.approve(address(this), amountToTransfer);
+        vm.stopPrank();
+
+        vm.startPrank(governor);
+        whitelistFleet.setWhitelisted(whitelistedRecipient, true);
+        whitelistFleet.setFleetTokenTransferability(true); // Enable transfers
+        whitelistFleet.setWhitelisted(address(this), true);
+        whitelistFleet.pause();
+        vm.stopPrank();
+
+        vm.expectRevert(abi.encodeWithSignature("EnforcedPause()"));
+        whitelistFleet.transferFrom(
+            mockUser,
+            whitelistedRecipient,
+            amountToTransfer
+        );
+    }
 }


### PR DESCRIPTION
**[M-05] ERC20 Transfers Bypass `whenNotPaused` Emergency Stop**

- **Location**: `FleetCommanderWhitelist.sol`
- **Description**: While `deposit`, `withdraw`, `mint`, and `redeem` are strictly gated by `whenNotPaused`, the `transfer` and `transferFrom` functions omit this modifier.
- **Exploit / Impact**: If the protocol is paused due to an active exploit, a compromised or distressed asset can still be freely moved and traded on secondary markets, or transferred to obfuscate tracking, defeating a key purpose of the pause functionality.