### PR TITLE
feat: gate safeTransferFrom and Batch version with whitelist

### DIFF
--- a/packages/core-contracts/src/contracts/rounds-vault/RoundsVaultBase.sol
+++ b/packages/core-contracts/src/contracts/rounds-vault/RoundsVaultBase.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.28;
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import {ERC1155} from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 
 import "@summerfi/price-solidity/contracts/PriceUtils.sol";
 
@@ -308,6 +310,50 @@ abstract contract RoundsVaultBase is
                 ids,
                 amounts
             );
+    }
+
+    /**
+        @inheritdoc IERC1155
+
+        @dev Gate the function so only whitelisted addresses can transfer receipts
+     */
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 id,
+        uint256 value,
+        bytes memory data
+    )
+        public
+        virtual
+        override(ERC1155, IERC1155)
+        onlyWhitelisted(from)
+        onlyWhitelisted(to)
+        onlyWhitelisted(_msgSender())
+    {
+        super.safeTransferFrom(from, to, id, value, data);
+    }
+
+    /**
+        @inheritdoc IERC1155
+
+        @dev Gate the function so only whitelisted addresses can transfer receipts in batch
+     */
+    function safeBatchTransferFrom(
+        address from,
+        address to,
+        uint256[] memory ids,
+        uint256[] memory values,
+        bytes memory data
+    )
+        public
+        virtual
+        override(ERC1155, IERC1155)
+        onlyWhitelisted(from)
+        onlyWhitelisted(to)
+        onlyWhitelisted(_msgSender())
+    {
+        super.safeBatchTransferFrom(from, to, ids, values, data);
     }
 
     // VIEW FUNCTIONS

--- a/packages/core-contracts/test/rounds-vault/RoundsVaultInput.t.sol
+++ b/packages/core-contracts/test/rounds-vault/RoundsVaultInput.t.sol
@@ -735,4 +735,142 @@ contract RoundsVaultInputTest is
         // 5. Check that balanceOfAll() correctly reflects the burned tokens
         assertEq(vault.balanceOfAll(accountB), 0);
     }
+
+    function test_RIV0015_TransferRevertIfFromNotWhitelisted() public {
+        address validCaller = address(0x4);
+        address to = address(0x5);
+        address from = unprivilegedAccount; // not whitelisted
+
+        // Disable open whitelist
+        vm.prank(admin);
+        vault.setWhitelisted(address(0), false);
+
+        vm.startPrank(admin);
+        vault.setWhitelisted(validCaller, true);
+        vault.setWhitelisted(to, true);
+        vm.stopPrank();
+
+        uint256 id = 0;
+        uint256 value = 0.2 ether;
+
+        vm.startPrank(validCaller);
+
+        vm.expectRevert(abi.encodeWithSelector(NotWhitelisted.selector, from));
+        vault.safeTransferFrom(from, to, id, value, "");
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = id;
+        uint256[] memory values = new uint256[](1);
+        values[0] = value;
+
+        vm.expectRevert(abi.encodeWithSelector(NotWhitelisted.selector, from));
+        vault.safeBatchTransferFrom(from, to, ids, values, "");
+
+        vm.stopPrank();
+    }
+
+    function test_RIV0016_TransferRevertIfToNotWhitelisted() public {
+        address validCaller = address(0x4);
+        address to = address(0x5); // not whitelisted
+        address from = unprivilegedAccount;
+
+        // Disable open whitelist
+        vm.prank(admin);
+        vault.setWhitelisted(address(0), false);
+
+        vm.startPrank(admin);
+        vault.setWhitelisted(validCaller, true);
+        vault.setWhitelisted(from, true);
+        vm.stopPrank();
+
+        uint256 id = 0;
+        uint256 value = 0.2 ether;
+
+        vm.startPrank(validCaller);
+
+        vm.expectRevert(abi.encodeWithSelector(NotWhitelisted.selector, to));
+        vault.safeTransferFrom(from, to, id, value, "");
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = id;
+        uint256[] memory values = new uint256[](1);
+        values[0] = value;
+
+        vm.expectRevert(abi.encodeWithSelector(NotWhitelisted.selector, to));
+        vault.safeBatchTransferFrom(from, to, ids, values, "");
+
+        vm.stopPrank();
+    }
+
+    function test_RIV0017_TransferRevertIfCallerNotWhitelisted() public {
+        address caller = address(0x4); // not whitelisted
+        address to = address(0x5);
+        address from = unprivilegedAccount;
+
+        // Disable open whitelist
+        vm.prank(admin);
+        vault.setWhitelisted(address(0), false);
+
+        vm.startPrank(admin);
+        vault.setWhitelisted(from, true);
+        vault.setWhitelisted(to, true);
+        vm.stopPrank();
+
+        uint256 id = 0;
+        uint256 value = 0.2 ether;
+
+        vm.startPrank(caller);
+
+        vm.expectRevert(abi.encodeWithSelector(NotWhitelisted.selector, caller));
+        vault.safeTransferFrom(from, to, id, value, "");
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = id;
+        uint256[] memory values = new uint256[](1);
+        values[0] = value;
+
+        vm.expectRevert(abi.encodeWithSelector(NotWhitelisted.selector, caller));
+        vault.safeBatchTransferFrom(from, to, ids, values, "");
+
+        vm.stopPrank();
+    }
+
+    function test_RIV0018_TransferSuccessWhenWhitelisted() public {
+        address validCaller = address(0x4);
+        address to = address(0x5);
+        address from = unprivilegedAccount;
+
+        // Disable open whitelist
+        vm.prank(admin);
+        vault.setWhitelisted(address(0), false);
+
+        // Prepare the state
+        uint256 value = 0.2 ether;
+
+        vm.startPrank(admin);
+        vault.setWhitelisted(from, true);
+        vault.setWhitelisted(to, true);
+        vault.setWhitelisted(validCaller, true);
+        vm.stopPrank();
+
+        vm.startPrank(from);
+        vault.deposit(value * 2, from);
+        vault.setApprovalForAll(validCaller, true);
+        vm.stopPrank();
+        
+        vm.startPrank(validCaller);
+        vault.safeTransferFrom(from, to, 0, value, "");
+        assertEq(vault.balanceOf(to, 0), value);
+        assertEq(vault.balanceOf(from, 0), value);
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = 0;
+        uint256[] memory values = new uint256[](1);
+        values[0] = value;
+
+        vault.safeBatchTransferFrom(from, to, ids, values, "");
+        assertEq(vault.balanceOf(to, 0), value * 2);
+        assertEq(vault.balanceOf(from, 0), 0);
+        vm.stopPrank();
+    }
 }


### PR DESCRIPTION
## Description
This PR introduces whitelist access control for ERC-1155 receipt transfers within the rounds vault system. By gating `safeTransferFrom` and `safeBatchTransferFrom`, we ensure that secondary transfers can only happen between explicitly verified/whitelisted actors. It also resolves a minor compiler override issue in `RoundsVaultBase.sol` and provides comprehensive test coverage to ensure the access controls work properly.
## Changes
- Overrode `safeTransferFrom` and `safeBatchTransferFrom` in `RoundsVaultBase.sol` locking them down with the `onlyWhitelisted` modifier for `from`, `to`, and `_msgSender()`.
- Added explicit `ERC1155` and `IERC1155` standard imports from OpenZeppelin to resolve compiler reference issues and correctly specified `override(ERC1155, IERC1155)`.
- Implemented comprehensive positive and negative Forge tests (`test_RIV0015` through `test_RIV0018`) in `RoundsVaultInput.t.sol` to cover all whitelist transfer constraints.
## Benefits
1. **Added Security Setup**: Enhances compliance by strictly ensuring all participants exchanging receipts have passed requisite whitelist verifications.
2. **Robust Quality Assurance**: Prevents regressions by adding explicit Forge tests mapping out failure states when any participant is absent from the whitelist.
3. **Compilation Fixes**: Smooths out build processes by formalizing multiple-inheritance overrides required by Solidity.
## Testing
Tested via Foundry `forge test`.
Explicitly added the following tests to `RoundsVaultInputTest`:
* `test_RIV0015_TransferRevertIfFromNotWhitelisted`
* `test_RIV0016_TransferRevertIfToNotWhitelisted`
* `test_RIV0017_TransferRevertIfCallerNotWhitelisted`
* `test_RIV0018_TransferSuccessWhenWhitelisted`
To test locally, run: `forge test --match-contract RoundsVaultInputTest` 

Please review and provide any feedback or suggestions for improvement.