### PR TITLE
fix: RWA L-05

### DIFF
--- a/packages/core-contracts/src/contracts/FleetCommanderWhitelist.sol
+++ b/packages/core-contracts/src/contracts/FleetCommanderWhitelist.sol
@@ -486,7 +486,7 @@ contract FleetCommanderWhitelist is
     /// @inheritdoc IFleetCommanderWhitelist
     function setPerformanceFeeRate(
         Percentage newRate
-    ) external onlyGovernor whenNotPaused {
+    ) external onlyGovernor whenNotPaused collectTip {
         _setPerformanceFeeRate(newRate);
     }
 

--- a/packages/core-contracts/src/contracts/FleetCommanderWhitelist.sol
+++ b/packages/core-contracts/src/contracts/FleetCommanderWhitelist.sol
@@ -486,8 +486,8 @@ contract FleetCommanderWhitelist is
     /// @inheritdoc IFleetCommanderWhitelist
     function setPerformanceFeeRate(
         Percentage newRate
-    ) external onlyGovernor whenNotPaused collectTip {
-        _setPerformanceFeeRate(newRate);
+    ) external onlyGovernor whenNotPaused {
+        _setPerformanceFeeRate(newRate, tipJar(), totalSupply());
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/packages/core-contracts/src/contracts/FlexibleTipper.sol
+++ b/packages/core-contracts/src/contracts/FlexibleTipper.sol
@@ -110,10 +110,10 @@ abstract contract FlexibleTipper is IFlexibleTipper, Tipper {
         address tipJar,
         uint256 _totalSupply
     ) internal {
-        _accrueTip(tipJar, _totalSupply);
         if (newRate > MAX_PERFORMANCE_FEE_RATE) {
             revert PerformanceFeeRateTooHigh();
         }
+        _accrueTip(tipJar, _totalSupply);
         performanceFeeRate = newRate;
         emit PerformanceFeeRateUpdated(newRate);
     }

--- a/packages/core-contracts/src/contracts/FlexibleTipper.sol
+++ b/packages/core-contracts/src/contracts/FlexibleTipper.sol
@@ -105,7 +105,12 @@ abstract contract FlexibleTipper is IFlexibleTipper, Tipper {
      * @param newRate The new performance fee rate
      * @dev Reverts if the rate exceeds 50%
      */
-    function _setPerformanceFeeRate(Percentage newRate) internal {
+    function _setPerformanceFeeRate(
+        Percentage newRate,
+        address tipJar,
+        uint256 _totalSupply
+    ) internal {
+        _accrueTip(tipJar, _totalSupply);
         if (newRate > MAX_PERFORMANCE_FEE_RATE) {
             revert PerformanceFeeRateTooHigh();
         }


### PR DESCRIPTION
**[L-05] `setPerformanceFeeRate` Retroactive Fee Manipulation**

- **Location**: `FlexibleTipper.sol`
- **Description**: Changing the performance fee rate immediately overwrites the state variable without first accruing pending fees.
- **Exploit / Impact**: A governor can retroactively apply a high fee rate to historical unaccrued profit. However, since fees are taken frequently (e.g. at rebalances), this is maximally a one-day amount of fees.