### PR TITLE
fix: RWA L-04

### DIFF
--- a/packages/core-contracts/src/extensions/ERC4626MultiToken.sol
+++ b/packages/core-contracts/src/extensions/ERC4626MultiToken.sol
@@ -76,7 +76,14 @@ abstract contract ERC4626MultiToken is
         return type(uint256).max;
     }
 
-    /** @dev See {IERC4626MultiToken-maxRedeem} */
+    /**
+     * @dev See {IERC4626MultiToken-maxRedeem}
+     * @notice Returns the total balance of all receipt IDs owned by the account.
+     * @dev WARNING: Standard ERC4626 routers may expect this to return the amount withdrawable
+     *      in a single operation. In this multi-token implementation, it represents the aggregate
+     *      across all rounds/IDs. Derived contracts (like RoundsVault) may have more restrictive
+     *      per-id or per-round limits.
+     */
     function maxRedeem(
         address owner
     ) public view virtual override returns (uint256) {


### PR DESCRIPTION
**[L-04] Semantics Break on ERC4626 `maxRedeem` [known]**

- **Location**: `ERC4626MultiToken.sol`
- **Description**: `maxRedeem(owner)` correctly identifies the total bounds of the receipts, but implements it as `balanceOfAll(owner)` (the aggregate of ALL rounds in history). Standard routers hitting this endpoint will receive an incorrectly massive `maxRedeem` value compared to what they can withdraw in the current round.