### PR TITLE
fix: RWA M-02

### DIFF
--- a/packages/core-contracts/src/contracts/FlexibleTipper.sol
+++ b/packages/core-contracts/src/contracts/FlexibleTipper.sol
@@ -26,6 +26,13 @@ import {PercentageUtils} from "@summerfi/percentage-solidity/contracts/Percentag
  * 1. The inheriting contract MUST implement `_getTotalAssetsForFee()`
  * 2. The inheriting contract MUST be ERC20-compliant (same as Tipper)
  * 3. When fee type changes, HWM resets to current assetsPerShare
+ *
+ * The protocol utilizes a global High-Water Mark (HWM) rather than tracking individual
+ * user entry prices. The team acknowledges that this design allows users who deposit
+ * during a drawdown to accrue yield without paying performance fees until the global
+ * HWM is surpassed. This is an intentional architectural decision made to maintain
+ * strict ERC-4626 share fungibility, ensure seamless integration with secondary DeFi
+ * markets, and actively incentivize fresh liquidity during protocol drawdowns.
  */
 abstract contract FlexibleTipper is IFlexibleTipper, Tipper {
     using PercentageUtils for uint256;


### PR DESCRIPTION
**[M-02] `setFeeType` HWM Reset Cancels Drawdown Recovery**

- **Location**: `FlexibleTipper.sol`
- **Description**: When the Governor calls `setFeeType` (e.g., from `BOTH` to `AUM`), the HWM resets to the current live `assetsPerShare`.
- **Exploit / Impact**: A malicious or unaware Governor can switch the fee type during a bear market drawdown. When the asset recovers back to its original price, the protocol will charge a performance fee on the "recovery" because the HWM was erased, double-charging users for identical yield.