### PR TITLE
feat: allow governor to rollback round

### DIFF
--- a/packages/core-contracts/src/contracts/rounds-vault/RoundsVaultBase.sol
+++ b/packages/core-contracts/src/contracts/rounds-vault/RoundsVaultBase.sol
@@ -111,7 +111,7 @@ abstract contract RoundsVaultBase is
      */
     function nextRound() external onlyKeeper {
         uint256 closingRound = _roundNumber;
-        
+
         _startSettlement(closingRound);
 
         _roundNumber++;
@@ -125,6 +125,10 @@ abstract contract RoundsVaultBase is
      * @inheritdoc IRoundsVaultBase
      */
     function retryRound(uint256 roundId) external onlyKeeper {
+        if (roundId >= _roundNumber) {
+            revert CannotRetryCurrentRound(roundId, _roundNumber);
+        }
+
         _startSettlement(roundId);
         emit RoundRetried(roundId);
     }

--- a/packages/core-contracts/src/contracts/rounds-vault/RoundsVaultBase.sol
+++ b/packages/core-contracts/src/contracts/rounds-vault/RoundsVaultBase.sol
@@ -111,20 +111,22 @@ abstract contract RoundsVaultBase is
      */
     function nextRound() external onlyKeeper {
         uint256 closingRound = _roundNumber;
-        if (roundState[closingRound] != RoundState.Opened) {
-            revert InvalidRoundState(
-                closingRound,
-                roundState[closingRound],
-                RoundState.Opened
-            );
-        }
-
-        roundState[closingRound] = RoundState.InSettlement;
+        
+        _startSettlement(closingRound);
 
         _roundNumber++;
+
         roundState[_roundNumber] = RoundState.Opened;
 
         emit RoundAdvanced(closingRound);
+    }
+
+    /**
+     * @inheritdoc IRoundsVaultBase
+     */
+    function retryRound(uint256 roundId) external onlyKeeper {
+        _startSettlement(roundId);
+        emit RoundRetried(roundId);
     }
 
     /**
@@ -143,6 +145,22 @@ abstract contract RoundsVaultBase is
         for (uint256 i = 0; i < roundIds.length; i++) {
             _setRoundSettled(roundIds[i]);
         }
+    }
+
+    /**
+     * @inheritdoc IRoundsVaultBase
+     */
+    function emergencyRollbackRound(uint256 roundId) external onlyGovernor {
+        if (roundState[roundId] != RoundState.InSettlement) {
+            revert InvalidRoundState(
+                roundId,
+                roundState[roundId],
+                RoundState.InSettlement
+            );
+        }
+
+        roundState[roundId] = RoundState.Opened;
+        emit EmergencyRoundRolledBack(roundId);
     }
 
     ///@inheritdoc Whitelist
@@ -202,8 +220,8 @@ abstract contract RoundsVaultBase is
         onlyWhitelisted(_msgSender())
         returns (uint256)
     {
-        if (id != _roundNumber) {
-            revert CanOnlyRedeemCurrentRound(id, _roundNumber);
+        if (roundState[id] != RoundState.Opened) {
+            revert InvalidRoundState(id, roundState[id], RoundState.Opened);
         }
 
         return super.redeem(id, amount, receiver, owner);
@@ -230,8 +248,12 @@ abstract contract RoundsVaultBase is
         returns (uint256 assets)
     {
         for (uint256 i = 0; i < ids.length; i++) {
-            if (ids[i] != _roundNumber) {
-                revert CanOnlyRedeemCurrentRound(ids[i], _roundNumber);
+            if (roundState[ids[i]] != RoundState.Opened) {
+                revert InvalidRoundState(
+                    ids[i],
+                    roundState[ids[i]],
+                    RoundState.Opened
+                );
             }
         }
 
@@ -334,6 +356,21 @@ abstract contract RoundsVaultBase is
     }
 
     // INTERNALS
+
+    /**
+     * @notice Helper function to mark an Opened round as InSettlement
+     */
+    function _startSettlement(uint256 roundId) internal {
+        if (roundState[roundId] != RoundState.Opened) {
+            revert InvalidRoundState(
+                roundId,
+                roundState[roundId],
+                RoundState.Opened
+            );
+        }
+
+        roundState[roundId] = RoundState.InSettlement;
+    }
 
     /**
         @inheritdoc ERC4626MultiToken

--- a/packages/core-contracts/src/interfaces/rounds-vault/IRoundsVaultBase.sol
+++ b/packages/core-contracts/src/interfaces/rounds-vault/IRoundsVaultBase.sol
@@ -116,4 +116,21 @@ interface IRoundsVaultBase is IERC4626MultiTokenWrapper {
         @dev Only the keeper can call this function
      */
     function setRoundSettledBatch(uint256[] calldata roundIds) external;
+
+    /**
+        @notice Forces a round that is stuck in the InSettlement state back to the Opened state.
+                This assumes that the operation to settle the round via _operate failed and liquidity needs 
+                to be categorized back to bypass the lock step.
+        @param roundId The ID of the round to be rolled back
+        @dev Only the governor can call this function.
+     */
+    function emergencyRollbackRound(uint256 roundId) external;
+
+    /**
+        @notice Retries a stuck round by putting it back into InSettlement from Opened state.
+        
+        @param roundId The ID of the round to retry.
+        @dev Only the keeper can call this function.
+     */
+    function retryRound(uint256 roundId) external;
 }

--- a/packages/core-contracts/src/interfaces/rounds-vault/IRoundsVaultBaseErrors.sol
+++ b/packages/core-contracts/src/interfaces/rounds-vault/IRoundsVaultBaseErrors.sol
@@ -41,4 +41,7 @@ interface IRoundsVaultBaseErrors {
         IRoundsVaultBaseEnums.RoundState currentRoundState,
         IRoundsVaultBaseEnums.RoundState expectedRoundState
     );
+
+    /// Error thrown when trying to retry a round that is not the current round
+    error CannotRetryCurrentRound(uint256 roundId, uint256 currentRound);
 }

--- a/packages/core-contracts/src/interfaces/rounds-vault/IRoundsVaultBaseEvents.sol
+++ b/packages/core-contracts/src/interfaces/rounds-vault/IRoundsVaultBaseEvents.sol
@@ -36,4 +36,10 @@ interface IRoundsVaultBaseEvents {
 
     /// Emitted when a round is marked as settled
     event RoundSettled(uint256 indexed roundId, Price exchangeRate);
+
+    /// Emitted when a stuck round in InSettlement is gracefully rolled back to Opened
+    event EmergencyRoundRolledBack(uint256 indexed roundId);
+
+    /// Emitted when a round that was in Opened state is placed back in InSettlement to attempt settlement again
+    event RoundRetried(uint256 indexed roundId);
 }

--- a/packages/core-contracts/test/rounds-vault/RoundsVaultInput.t.sol
+++ b/packages/core-contracts/test/rounds-vault/RoundsVaultInput.t.sol
@@ -367,7 +367,12 @@ contract RoundsVaultInputTest is
 
         // Try to redeem normal (should fail)
         vm.expectRevert(
-            abi.encodeWithSelector(CanOnlyRedeemCurrentRound.selector, 1, 2)
+            abi.encodeWithSelector(
+                InvalidRoundState.selector,
+                1,
+                IRoundsVaultBaseEnums.RoundState.Settled,
+                IRoundsVaultBaseEnums.RoundState.Opened
+            )
         );
         vault.redeem(1, assets, unprivilegedAccount, unprivilegedAccount);
 
@@ -422,7 +427,12 @@ contract RoundsVaultInputTest is
 
         // Try to redeem normal (should fail)
         vm.expectRevert(
-            abi.encodeWithSelector(CanOnlyRedeemCurrentRound.selector, 1, 3)
+            abi.encodeWithSelector(
+                InvalidRoundState.selector,
+                1,
+                IRoundsVaultBaseEnums.RoundState.Settled,
+                IRoundsVaultBaseEnums.RoundState.Opened
+            )
         );
         vault.redeem(1, assets / 2, unprivilegedAccount, unprivilegedAccount);
 
@@ -734,5 +744,79 @@ contract RoundsVaultInputTest is
 
         // 5. Check that balanceOfAll() correctly reflects the burned tokens
         assertEq(vault.balanceOfAll(accountB), 0);
+    }
+    function test_RIV0015_EmergencyRollbackRound() public {
+        vm.startPrank(operator);
+        vault.nextRound(); // Round 0 -> InSettlement
+        vm.stopPrank();
+
+        assertEq(uint(vault.roundState(0)), uint(IRoundsVaultBaseEnums.RoundState.InSettlement));
+
+        // Negative: Non-governor cannot rollback
+        vm.startPrank(unprivilegedAccount);
+        vm.expectRevert(); // AccessControl revert
+        vault.emergencyRollbackRound(0);
+        vm.stopPrank();
+
+        // Negative: Cannot rollback a round that is not InSettlement
+        vm.startPrank(admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                InvalidRoundState.selector,
+                1,
+                IRoundsVaultBaseEnums.RoundState.Opened,
+                IRoundsVaultBaseEnums.RoundState.InSettlement
+            )
+        );
+        vault.emergencyRollbackRound(1); // Round 1 is Opened
+
+        // Positive: Rollback
+        vm.expectEmit(true, false, false, true);
+        emit EmergencyRoundRolledBack(0);
+        vault.emergencyRollbackRound(0);
+        
+        assertEq(uint(vault.roundState(0)), uint(IRoundsVaultBaseEnums.RoundState.Opened));
+        vm.stopPrank();
+    }
+
+    function test_RIV0016_RetryRound() public {
+        vm.startPrank(operator);
+        vault.nextRound(); // Round 0 -> InSettlement
+        vm.stopPrank();
+
+        vm.startPrank(admin);
+        vault.emergencyRollbackRound(0); // Round 0 -> Opened
+        vm.stopPrank();
+
+        assertEq(uint(vault.roundState(0)), uint(IRoundsVaultBaseEnums.RoundState.Opened));
+
+        // Negative: Non-keeper cannot retry round
+        vm.startPrank(unprivilegedAccount);
+        vm.expectRevert(); // AccessControl revert
+        vault.retryRound(0);
+        vm.stopPrank();
+
+        // Negative: Cannot retry a round that is not Opened
+        vm.startPrank(operator);
+        vault.nextRound(); // Round 1 -> InSettlement
+        vault.setRoundSettled(1); // Round 1 -> Settled
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                InvalidRoundState.selector,
+                1,
+                IRoundsVaultBaseEnums.RoundState.Settled,
+                IRoundsVaultBaseEnums.RoundState.Opened
+            )
+        );
+        vault.retryRound(1); // Round 1 is Settled
+
+        // Positive: Retry Round 0
+        vm.expectEmit(true, false, false, true);
+        emit RoundRetried(0);
+        vault.retryRound(0);
+        
+        assertEq(uint(vault.roundState(0)), uint(IRoundsVaultBaseEnums.RoundState.InSettlement));
+        vm.stopPrank();
     }
 }

--- a/packages/core-contracts/test/rounds-vault/RoundsVaultOutput.t.sol
+++ b/packages/core-contracts/test/rounds-vault/RoundsVaultOutput.t.sol
@@ -630,4 +630,78 @@ contract RoundsVaultOutputTest is
         vault.redeemExchangeAssetBatch(ids, amounts, receiver, owner);
         vm.stopPrank();
     }
+    function test_ROV0015_EmergencyRollbackRound() public {
+        vm.startPrank(operator);
+        vault.nextRound(); // Round 0 -> InSettlement
+        vm.stopPrank();
+
+        assertEq(uint(vault.roundState(0)), uint(IRoundsVaultBaseEnums.RoundState.InSettlement));
+
+        // Negative: Non-governor cannot rollback
+        vm.startPrank(unprivilegedAccount);
+        vm.expectRevert(); // AccessControl revert
+        vault.emergencyRollbackRound(0);
+        vm.stopPrank();
+
+        // Negative: Cannot rollback a round that is not InSettlement
+        vm.startPrank(admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                InvalidRoundState.selector,
+                1,
+                IRoundsVaultBaseEnums.RoundState.Opened,
+                IRoundsVaultBaseEnums.RoundState.InSettlement
+            )
+        );
+        vault.emergencyRollbackRound(1); // Round 1 is Opened
+
+        // Positive: Rollback
+        vm.expectEmit(true, false, false, true);
+        emit EmergencyRoundRolledBack(0);
+        vault.emergencyRollbackRound(0);
+        
+        assertEq(uint(vault.roundState(0)), uint(IRoundsVaultBaseEnums.RoundState.Opened));
+        vm.stopPrank();
+    }
+
+    function test_ROV0016_RetryRound() public {
+        vm.startPrank(operator);
+        vault.nextRound(); // Round 0 -> InSettlement
+        vm.stopPrank();
+
+        vm.startPrank(admin);
+        vault.emergencyRollbackRound(0); // Round 0 -> Opened
+        vm.stopPrank();
+
+        assertEq(uint(vault.roundState(0)), uint(IRoundsVaultBaseEnums.RoundState.Opened));
+
+        // Negative: Non-keeper cannot retry round
+        vm.startPrank(unprivilegedAccount);
+        vm.expectRevert(); // AccessControl revert
+        vault.retryRound(0);
+        vm.stopPrank();
+
+        // Negative: Cannot retry a round that is not Opened
+        vm.startPrank(operator);
+        vault.nextRound(); // Round 1 -> InSettlement
+        vault.setRoundSettled(1); // Round 1 -> Settled
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                InvalidRoundState.selector,
+                1,
+                IRoundsVaultBaseEnums.RoundState.Settled,
+                IRoundsVaultBaseEnums.RoundState.Opened
+            )
+        );
+        vault.retryRound(1); // Round 1 is Settled
+
+        // Positive: Retry Round 0
+        vm.expectEmit(true, false, false, true);
+        emit RoundRetried(0);
+        vault.retryRound(0);
+        
+        assertEq(uint(vault.roundState(0)), uint(IRoundsVaultBaseEnums.RoundState.InSettlement));
+        vm.stopPrank();
+    }
 }


### PR DESCRIPTION
## Description
This PR introduces vital emergency recovery and retry mechanisms to the `RoundsVault` architecture. It implements `emergencyRollbackRound` to rollback any specific stuck round to prevent funds from being permanently locked in stranded rounds. Alongside this, it introduces `retryRound` to securely resurrect rounds back into the `InSettlement` phase after they are salvaged. Together, these tools offer much more flexibility for Keeper operations and governance to safely handle complex or failing API integrations without halting the entire protocol.

## Changes
- **Implemented `emergencyRollbackRound(uint256 roundId)`:** Added a new `onlyGovernor` function that allows governance to force a specific round stuck in `InSettlement` back to the `Opened` state.
- **Implemented `retryRound(uint256 roundId)`:** Added a new `onlyKeeper` function allowing a specific `Opened` round to transition back to `InSettlement` natively via the internal `_startSettlement` helper.
- **Abstracted `_startSettlement(uint256 roundId)`:** Safely isolates the transition logic from `Opened` to `InSettlement` to be shared between standard `nextRound()` execution and targeted `retryRound()`.
- **Added Event Signatures:** Introduced the `EmergencyRoundRolledBack` and `RoundRetried` events into `IRoundsVaultBaseEvents.sol` to track operations correctly.
- **Updated `IRoundsVaultBase` Interface:** Exposed and documented `emergencyRollbackRound` and `retryRound`.

## Benefits
1. **Stranded rounds can now be recovered:** Governance has a direct mechanism to unlock operations stuck in Settlement.
2. **Keeper flexibility in executing operations:** Allow automated Keepers the native ability to retry settlement attempts on specific salvaged rounds without jumping the global `_roundNumber` state.
3. **Reduced code duplication and error reduction:** Encapsulating standard settlement state transitions via `_startSettlement()` guarantees a secure transition interface. 

## Testing
- Added specific tests to `RoundsVaultInput.t.sol` and `RoundsVaultOutput.t.sol` for `emergencyRollbackRound` (verifying successful `InSettlement` rollback and checking `onlyGovernor`/wrong state reverts).
- Tested `retryRound` natively across input and output Vaults (verifying successful `InSettlement` retry initialization and checking `onlyKeeper`/wrong state reverts). 
- Updated expected reverts for old tests checking `CanOnlyRedeemCurrentRound` inside `test_RIV0007_DepositRedeemPreviousRound` and `test_RIV0008` (now safely catching standard `InvalidRoundState`). 
- Fully verified under `forge build` and `forge test`.

Please review and provide any feedback or suggestions for improvement.
