### PR TITLE
fix: RWA C-01

### DIFF
--- a/packages/core-contracts/src/contracts/arks/WisdomTreeArk.sol
+++ b/packages/core-contracts/src/contracts/arks/WisdomTreeArk.sol
@@ -68,6 +68,10 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
     Percentage public constant MAX_SWEEP_SLIPPAGE =
         Percentage.wrap(PERCENTAGE_FACTOR / 2);
 
+    /// @notice Maximum deposit slippage (0.5%)
+    Percentage public constant MAX_DEPOSIT_SLIPPAGE =
+        Percentage.wrap(PERCENTAGE_FACTOR / 2);
+
     /// @notice Timeout for the oracle heartbeat (24 hours)
     uint256 public constant ORACLE_HEARTBEAT_TIMEOUT = 24 hours;
 
@@ -83,12 +87,17 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
     error InsufficientPendingDeposit();
     error PendingDepositActive();
     error ArkIsFrozen();
+    error InvalidDepositSlippage(
+        Percentage newSlippage,
+        Percentage maxSlippage
+    );
     error InvalidSweepSlippage(Percentage newSlippage, Percentage maxSlippage);
     error InsufficientAssetsReturned(
         uint256 receivedAssets,
         uint256 expectedShares,
         uint256 receivedShares
     );
+    error SharesNotArrived(uint256 expectedShares, uint256 actualNewShares);
 
     /*//////////////////////////////////////////////////////////////
                             EVENTS
@@ -101,6 +110,10 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
     event SweepSlippageUpdated(
         Percentage oldSweepSlippage,
         Percentage newSweepSlippage
+    );
+    event DepositSlippageUpdated(
+        Percentage oldDepositSlippage,
+        Percentage newDepositSlippage
     );
 
     /*//////////////////////////////////////////////////////////////
@@ -146,6 +159,9 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
     /// @notice Maximum slippage for the sweep swap
     Percentage public sweepSlippage;
 
+    /// @notice Maximum slippage for deposit clearance
+    Percentage public depositSlippage;
+
     /// @notice Total assets of the ark when it was frozen
     uint256 private _frozenTotalAssets;
 
@@ -158,6 +174,7 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
         address _shareToken,
         address _oracle,
         Percentage _sweepSlippage,
+        Percentage _depositSlippage,
         WTArkType _arkType,
         ArkParams memory _params
     ) ArkWithWithdrawalRequest(_params, DEFAULT_SWAP_SLIPPAGE) {
@@ -168,12 +185,27 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
         custodianWallet = _custodianWallet;
         shareToken = IERC20(_shareToken);
         oracle = AggregatorV3Interface(_oracle);
+        if (_sweepSlippage > MAX_SWEEP_SLIPPAGE) {
+            revert InvalidSweepSlippage(_sweepSlippage, MAX_SWEEP_SLIPPAGE);
+        }
+        if (_depositSlippage > MAX_DEPOSIT_SLIPPAGE) {
+            revert InvalidDepositSlippage(
+                _depositSlippage,
+                MAX_DEPOSIT_SLIPPAGE
+            );
+        }
         sweepSlippage = _sweepSlippage;
+        depositSlippage = _depositSlippage;
         oracleDecimals = AggregatorV3Interface(_oracle).decimals();
         shareDecimals = IERC20Metadata(_shareToken).decimals();
         assetDecimals = IERC20Metadata(_params.asset).decimals();
         ONE_ASSET = 10 ** assetDecimals;
         arkType = _arkType;
+    }
+
+    modifier onlyNotFrozen() {
+        if (isArkFrozen) revert ArkIsFrozen();
+        _;
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -251,6 +283,7 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
      * @notice Freezes or unfreezes deposits for this Ark.
      * @param _isArkFrozen The new frozen state
      * @param frozenTotalAssets The total assets of the ark when it was frozen
+     * @dev we use type(uint256).max as default trigger
      */
     function setArkFrozen(
         bool _isArkFrozen,
@@ -273,6 +306,7 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
      *      Assumes full clearance (no partial fills).
      */
     function clearPendingDeposit() external onlyKeeper {
+        _validateReceivedShares(pendingDepositAssets);
         _clearPendingDeposit(pendingDepositAssets);
     }
 
@@ -282,6 +316,7 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
      *      clear a partial deposit.
      */
     function clearPendingDeposit(uint256 amount) external onlyKeeper {
+        _validateReceivedShares(amount);
         _clearPendingDeposit(amount);
     }
 
@@ -290,10 +325,9 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
      * @notice Calculates the equivalent shares for the requested `amount` and sends them to the `custodianWallet`.
      * @dev Also records the the pending withdrawal shares. Reverts if deposit is pending.
      */
-    function requestWithdrawal(uint256 amount) external override onlyKeeper {
-        // Deposits and withdrawals are locked if ark is frozen
-        if (isArkFrozen) revert ArkIsFrozen();
-
+    function requestWithdrawal(
+        uint256 amount
+    ) external override onlyKeeper onlyNotFrozen {
         // Prevent concurrent deposit/withdrawal cycles
         if (pendingDepositAssets > 0) revert PendingDepositActive();
 
@@ -376,7 +410,20 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
     }
 
     /**
-     * @notice Internal function for sweeping assets from the forwarder
+     * @notice Accepts current share balance as valid
+     * @dev Called by governor in case of execution delays causing slippage reverts,
+     * or if WisdomTree partially fills an order in a way the Keeper cannot process.
+     * @param amount The amount of pending USDC deposit to forcefully clear.
+     */
+    function emergencyClearPendingDeposit(
+        uint256 amount
+    ) external onlyGovernor {
+        if (amount > pendingDepositAssets) revert InsufficientPendingDeposit();
+        _clearPendingDeposit(amount);
+    }
+
+    /**
+     * @notice Internal function for sweeping assets
      */
     function _sweep(
         uint256 amountToSweep
@@ -397,7 +444,7 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
         address bufferArk = address(
             IFleetCommander(config.commander).bufferArk()
         );
-        // to keep compatibility with the subgraph
+        // to keep compatibility with the indexer
         emit Disembarked(msg.sender, address(asset), sweptAmounts[0]);
 
         if (sweptAmounts[0] > 0 && address(this) != bufferArk) {
@@ -422,6 +469,25 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
         sweepSlippage = newSweepSlippage;
     }
 
+    /**
+     * @notice Sets the deposit slippage
+     * @param newDepositSlippage The new deposit slippage
+     */
+    function setDepositSlippage(
+        Percentage newDepositSlippage
+    ) external onlyKeeper {
+        if (newDepositSlippage > MAX_DEPOSIT_SLIPPAGE) {
+            revert InvalidDepositSlippage(
+                newDepositSlippage,
+                MAX_DEPOSIT_SLIPPAGE
+            );
+        }
+
+        emit DepositSlippageUpdated(depositSlippage, newDepositSlippage);
+
+        depositSlippage = newDepositSlippage;
+    }
+
     /*//////////////////////////////////////////////////////////////
                          INTERNAL FUNCTIONS
     //////////////////////////////////////////////////////////////*/
@@ -430,19 +496,14 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
      * @notice Caches placeholder deposit and sends USDC to WisdomTree target wallet.
      * @dev If this is the start of a deposit queue, snapshots the real share balance.
      */
-    function _board(uint256 amount, bytes calldata) internal override {
-        // Deposits and withdrawals are locked if ark is frozen
-        if (isArkFrozen) revert ArkIsFrozen();
-
-        // Non-money market arks cannot have concurrent deposits
-        if (arkType == WTArkType.NonMoneyMarket && pendingDepositAssets > 0) {
+    function _board(
+        uint256 amount,
+        bytes calldata
+    ) internal override onlyNotFrozen {
+        if (pendingDepositAssets > 0) {
             revert PendingDepositActive();
         }
-
-        if (pendingDepositAssets == 0) {
-            cachedShareBalance = shareToken.balanceOf(address(this));
-        }
-
+        cachedShareBalance = shareToken.balanceOf(address(this));
         pendingDepositAssets += amount;
 
         config.asset.safeTransfer(custodianWallet, amount);
@@ -451,11 +512,10 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
     /**
      * @dev No-op: Withdrawals are fully asynchronous via `requestWithdrawal` and `sweep`.
      */
-    function _disembark(uint256, bytes calldata) internal view override {
-        if (isArkFrozen) {
-            revert ArkIsFrozen();
-        }
-    }
+    function _disembark(
+        uint256,
+        bytes calldata
+    ) internal view override onlyNotFrozen {}
 
     /**
      * @dev Always 0: Synchronous withdrawal is not supported.
@@ -548,13 +608,26 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
 
     /**
      * @notice Removes a fulfilled deposit amount from `pendingDepositAssets`.
-     * @param amount The amount of deposit to clear.
+     * @param amountCleared The amount of USDC pending deposit to clear.
      */
-    function _clearPendingDeposit(uint256 amount) internal {
+    function _clearPendingDeposit(uint256 amountCleared) internal {
+        pendingDepositAssets -= amountCleared;
+        cachedShareBalance = shareToken.balanceOf(address(this));
+
+        emit PendingDepositCleared(amountCleared);
+    }
+
+    function _validateReceivedShares(uint256 amount) internal view {
         if (amount > pendingDepositAssets) revert InsufficientPendingDeposit();
+        uint256 currentShares = shareToken.balanceOf(address(this));
+        uint256 newlyArrivedShares = currentShares - cachedShareBalance;
+        uint256 expectedShares = _assetsToShares(amount);
+        uint256 expectedSharesMinusSlippage = expectedShares.subtractPercentage(
+            depositSlippage
+        );
 
-        pendingDepositAssets -= amount;
-
-        emit PendingDepositCleared(amount);
+        if (newlyArrivedShares < expectedSharesMinusSlippage) {
+            revert SharesNotArrived(expectedShares, newlyArrivedShares);
+        }
     }
 }

--- a/packages/core-contracts/src/contracts/arks/WisdomTreeArk.sol
+++ b/packages/core-contracts/src/contracts/arks/WisdomTreeArk.sol
@@ -14,31 +14,37 @@ import "@summerfi/price-solidity/contracts/PriceUtils.sol";
  * @notice Ark for managing off-chain WisdomTree tokenised assets (e.g. WTBTC).
  *
  * @dev Asset tracking model:
- *   totalAssets() = (actualShares * oraclePrice) + pendingDepositAssets + (pendingWithdrawalShares * oraclePrice)
+ * totalAssets() = (actualShares * oraclePrice) + pendingDepositAssets + (pendingWithdrawalShares * oraclePrice)
  *
- *   Lifecycle:
- *   1. Deposit (`_board`):
- *      - If it's the first deposit in the queue (`pendingDepositAssets == 0`),
- *        the Ark snapshots its live share balance into `cachedShareBalance`.
- *      - USDC is transferred to `custodianWallet`.
- *      - `pendingDepositAssets` increases by the sent amount.
+ * Lifecycle:
+ * 1. Deposit (`_board`):
+ * - If it's the first deposit in the queue (`pendingDepositAssets == 0`),
+ * the Ark snapshots its live share balance into `cachedShareBalance`.
+ * - USDC is transferred to `custodianWallet`.
+ * - `pendingDepositAssets` increases by the sent amount.
  *
- *   2. Share Delivery & Keeper Deposit Clearance (`clearPendingDeposit`):
- *      - WisdomTree mints shares and transfers them to this Ark off-chain.
- *      - While `pendingDepositAssets > 0`, `totalAssets` uses `cachedShareBalance`,
- *        so the newly arriving shares are NOT double-counted.
- *      - The Keeper observes the incoming shares and calls `clearPendingDeposit`.
- *        This resets `pendingDepositAssets` to 0 (we assume no partial fills),
- *        releases the cache, and `totalAssets` switches back to using the pure live balance.
+ * 2. Share Delivery & Deposit Clearance (`clearPendingDeposit`):
+ * - WisdomTree mints shares and transfers them to this Ark off-chain.
+ * - While `pendingDepositAssets > 0`, `totalAssets` uses `cachedShareBalance` to prevent double-counting.
+ * - The Keeper calls `clearPendingDeposit(amount)`. The contract mathematically verifies
+ * that the expected shares (minus `depositSlippage`) have actually arrived before allowing clearance.
+ * - Supports partial clearances: `pendingDepositAssets` decreases, and `cachedShareBalance` updates
+ * safely to capture the newly delivered shares.
  *
- *   3. Withdrawal Request (`requestWithdrawal`):
- *      - Calculates equivalent shares and transfers them to `custodianWallet`.
- *      - Reduces `cachedShareBalance` (if frozen) to prevent artificial value propping.
- *      - Increases `pendingWithdrawalShares`.
+ * 3. Withdrawal Request (`requestWithdrawal`):
+ * - Only allowed when `pendingDepositAssets == 0` (prevents concurrent deposit/withdrawal cycles).
+ * - Calculates equivalent shares using the oracle and transfers them to `custodianWallet`.
+ * - Increases `pendingWithdrawalShares`.
  *
- *   4. Sweep (`sweep`):
- *      - USDC arrives from WisdomTree. Keeper calls `sweep()`.
- *      - `pendingWithdrawalShares = 0`. USDC swept to `bufferArk`.
+ * 4. Sweep (`sweep`):
+ * - USDC arrives from WisdomTree. Keeper calls `sweep()`.
+ * - Verifies that returned USDC meets the expected `sweepSlippage` threshold based on current oracle price.
+ * - `pendingWithdrawalShares = 0`. USDC swept to `bufferArk`.
+ *
+ * 5. Emergency Fallbacks:
+ * - `emergencySweep()` and `emergencyClearPendingDeposit()` allow the Governor to safely bypass
+ * slippage and oracle checks in case of extreme market volatility, partial fills the Keeper cannot process, or oracle
+ * deadlocks.
  */
 contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
     using SafeERC20 for IERC20;
@@ -52,14 +58,6 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
     /*//////////////////////////////////////////////////////////////
                                   ENUMS
     //////////////////////////////////////////////////////////////*/
-
-    /// @notice Type of Ark (MoneyMarket or NonMoneyMarket)
-    /// @dev MoneyMarket arks can have multiple deposits at once
-    /// @dev NonMoneyMarket arks can only have one deposit at a time
-    enum WTArkType {
-        NonMoneyMarket,
-        MoneyMarket
-    }
 
     /// @notice Default slippage (0.02%)
     uint256 public constant DEFAULT_SWAP_SLIPPAGE = 2;
@@ -150,9 +148,6 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
     /// @notice Expected returning USDC amount equivalent to redeemed shares.
     uint256 public pendingWithdrawalShares;
 
-    /// @notice Type of Ark (MoneyMarket or NonMoneyMarket)
-    WTArkType public immutable arkType;
-
     /// @notice Report of shares is given from cache or not
     bool public isArkFrozen;
 
@@ -175,7 +170,6 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
         address _oracle,
         Percentage _sweepSlippage,
         Percentage _depositSlippage,
-        WTArkType _arkType,
         ArkParams memory _params
     ) ArkWithWithdrawalRequest(_params, DEFAULT_SWAP_SLIPPAGE) {
         if (_custodianWallet == address(0)) revert InvalidTargetWallet();
@@ -200,7 +194,6 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
         shareDecimals = IERC20Metadata(_shareToken).decimals();
         assetDecimals = IERC20Metadata(_params.asset).decimals();
         ONE_ASSET = 10 ** assetDecimals;
-        arkType = _arkType;
     }
 
     modifier onlyNotFrozen() {

--- a/packages/core-contracts/test/arks/WisdomTreeArk.t.sol
+++ b/packages/core-contracts/test/arks/WisdomTreeArk.t.sol
@@ -144,7 +144,6 @@ contract WisdomTreeArkTest is Test, IArkEvents, ArkTestBaseWhitelist {
             address(oracle),
             sweepSlippage,
             depositSlippage,
-            WisdomTreeArk.WTArkType.NonMoneyMarket,
             params
         );
         vm.stopPrank();
@@ -183,7 +182,6 @@ contract WisdomTreeArkTest is Test, IArkEvents, ArkTestBaseWhitelist {
             address(oracle),
             Percentage.wrap(PERCENTAGE_FACTOR / 2),
             Percentage.wrap(PERCENTAGE_FACTOR / 2),
-            WisdomTreeArk.WTArkType.NonMoneyMarket,
             params
         );
 
@@ -194,7 +192,6 @@ contract WisdomTreeArkTest is Test, IArkEvents, ArkTestBaseWhitelist {
             address(0),
             Percentage.wrap(PERCENTAGE_FACTOR / 2),
             Percentage.wrap(PERCENTAGE_FACTOR / 2),
-            WisdomTreeArk.WTArkType.NonMoneyMarket,
             params
         );
 
@@ -205,7 +202,6 @@ contract WisdomTreeArkTest is Test, IArkEvents, ArkTestBaseWhitelist {
             address(oracle),
             Percentage.wrap(PERCENTAGE_FACTOR / 2),
             Percentage.wrap(PERCENTAGE_FACTOR / 2),
-            WisdomTreeArk.WTArkType.NonMoneyMarket,
             params
         );
 
@@ -919,7 +915,7 @@ contract WisdomTreeArkTest is Test, IArkEvents, ArkTestBaseWhitelist {
         vm.startPrank(governor);
 
         vm.expectEmit(false, false, false, true);
-        emit PendingDepositCleared(clearanceAttempt);
+        emit WisdomTreeArk.PendingDepositCleared(clearanceAttempt);
 
         ark.emergencyClearPendingDeposit(clearanceAttempt);
         vm.stopPrank();

--- a/packages/core-contracts/test/arks/WisdomTreeArk.t.sol
+++ b/packages/core-contracts/test/arks/WisdomTreeArk.t.sol
@@ -137,11 +137,13 @@ contract WisdomTreeArkTest is Test, IArkEvents, ArkTestBaseWhitelist {
 
         vm.startPrank(governor);
         Percentage sweepSlippage = Percentage.wrap(PERCENTAGE_FACTOR / 2);
+        Percentage depositSlippage = Percentage.wrap(PERCENTAGE_FACTOR / 2);
         ark = new WisdomTreeArk(
             targetWallet,
             address(wtToken),
             address(oracle),
             sweepSlippage,
+            depositSlippage,
             WisdomTreeArk.WTArkType.NonMoneyMarket,
             params
         );
@@ -180,6 +182,7 @@ contract WisdomTreeArkTest is Test, IArkEvents, ArkTestBaseWhitelist {
             address(wtToken),
             address(oracle),
             Percentage.wrap(PERCENTAGE_FACTOR / 2),
+            Percentage.wrap(PERCENTAGE_FACTOR / 2),
             WisdomTreeArk.WTArkType.NonMoneyMarket,
             params
         );
@@ -190,6 +193,7 @@ contract WisdomTreeArkTest is Test, IArkEvents, ArkTestBaseWhitelist {
             address(wtToken),
             address(0),
             Percentage.wrap(PERCENTAGE_FACTOR / 2),
+            Percentage.wrap(PERCENTAGE_FACTOR / 2),
             WisdomTreeArk.WTArkType.NonMoneyMarket,
             params
         );
@@ -199,6 +203,7 @@ contract WisdomTreeArkTest is Test, IArkEvents, ArkTestBaseWhitelist {
             targetWallet,
             address(0),
             address(oracle),
+            Percentage.wrap(PERCENTAGE_FACTOR / 2),
             Percentage.wrap(PERCENTAGE_FACTOR / 2),
             WisdomTreeArk.WTArkType.NonMoneyMarket,
             params
@@ -439,6 +444,8 @@ contract WisdomTreeArkTest is Test, IArkEvents, ArkTestBaseWhitelist {
         assertEq(ark.pendingDepositAssets(), amount);
 
         uint256 clearAmount = 10000 * 1e6;
+        uint256 equivalentShares = (clearAmount * 1e18) / amount;
+        deal(address(wtToken), address(ark), equivalentShares);
 
         vm.startPrank(keeper);
         ark.clearPendingDeposit(clearAmount);
@@ -722,5 +729,223 @@ contract WisdomTreeArkTest is Test, IArkEvents, ArkTestBaseWhitelist {
         oracle.setRoundData(1, 60000 * 1e8, 0, 1);
         vm.expectRevert(WisdomTreeArk.StaleOraclePrice.selector);
         ark.sharesToAssets(1e18);
+    }
+
+    function test_ClearPendingDeposit_RevertsIfSharesNotArrived() public {
+        // 1. Board exact price of 1 share
+        uint256 amount = 60000 * 1e6;
+        deal(USDC_ADDRESS, commander, amount);
+
+        vm.startPrank(commander);
+        usdc.forceApprove(address(ark), amount);
+        ark.board(amount, bytes(""));
+        vm.stopPrank();
+
+        // 2. NO SHARES ARE MINTED OFF-CHAIN YET.
+        // This simulates a malicious or overly fast Keeper trying to crash the NAV.
+
+        uint256 expectedShares = 1e18; // 1 WTBTC
+
+        // 3. Keeper attempts to clear. Must revert with our new custom error.
+        vm.startPrank(keeper);
+
+        // We expect SharesNotArrived(expectedShares, actualNewShares)
+        // Adjust the expected error signature to match exactly what you implemented
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                WisdomTreeArk.SharesNotArrived.selector,
+                expectedShares,
+                0 // 0 shares actually arrived
+            )
+        );
+        ark.clearPendingDeposit();
+        vm.stopPrank();
+
+        // Ensure state remains intact
+        assertEq(
+            ark.pendingDepositAssets(),
+            amount,
+            "Pending deposit should remain untouched"
+        );
+    }
+
+    function test_ClearPendingDeposit_RevertsIfOutsideSlippage() public {
+        uint256 amount = 60000 * 1e6; // Boarding 60k USDC, expecting 1 Share
+        deal(USDC_ADDRESS, commander, amount);
+
+        vm.startPrank(commander);
+        usdc.forceApprove(address(ark), amount);
+        ark.board(amount, bytes(""));
+        vm.stopPrank();
+
+        // 2. Shares arrive, but it's significantly less than expected
+        // Outside the allowed deposit slippage (e.g., 0.5%)
+        uint256 shortSharesMinted = 0.9e18;
+        wtToken.mint(address(ark), shortSharesMinted);
+
+        uint256 expectedShares = 1e18;
+
+        vm.startPrank(keeper);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                WisdomTreeArk.SharesNotArrived.selector,
+                expectedShares,
+                shortSharesMinted
+            )
+        );
+        ark.clearPendingDeposit();
+        vm.stopPrank();
+    }
+
+    function test_ClearPendingDeposit_WithSlippage_Success() public {
+        uint256 amount = 60000 * 1e6;
+        deal(USDC_ADDRESS, commander, amount);
+
+        vm.startPrank(commander);
+        usdc.forceApprove(address(ark), amount);
+        ark.board(amount, bytes(""));
+        vm.stopPrank();
+
+        // 2. Shares arrive with a tiny bit of negative slippage (0.2% loss).
+        // 1 Share - 0.2% = 0.998 Shares.
+        // Assuming your depositSlippage is set to 0.5%, this should pass.
+        uint256 slightlyShortShares = 0.9981e18;
+        wtToken.mint(address(ark), slightlyShortShares);
+
+        vm.startPrank(keeper);
+        ark.clearPendingDeposit(); // Should succeed
+        vm.stopPrank();
+
+        assertEq(
+            ark.pendingDepositAssets(),
+            0,
+            "Deposit should be cleared despite slight slippage"
+        );
+
+        // Ensure the cached share balance caught the slightly short shares perfectly
+        assertEq(
+            ark.cachedShareBalance(),
+            slightlyShortShares,
+            "Cache should update to the exact actual shares"
+        );
+    }
+
+    function test_ClearPendingDeposit_PartialClearance_SafeUpdate() public {
+        // Board 120k USDC (Expect 2 Shares)
+        uint256 amount = 120000 * 1e6;
+        deal(USDC_ADDRESS, commander, amount);
+
+        vm.startPrank(commander);
+        usdc.forceApprove(address(ark), amount);
+        ark.board(amount, bytes(""));
+        vm.stopPrank();
+
+        // Only 1 Share arrives off-chain initially
+        uint256 partialSharesMinted = 1e18;
+        wtToken.mint(address(ark), partialSharesMinted);
+
+        uint256 partialClearance = 60000 * 1e6; // Clear half the USDC
+
+        vm.startPrank(keeper);
+        ark.clearPendingDeposit(partialClearance); // Clear half
+        vm.stopPrank();
+
+        // Verify partial state
+        assertEq(
+            ark.pendingDepositAssets(),
+            60000 * 1e6,
+            "Half of the deposit should still be pending"
+        );
+        assertEq(
+            ark.cachedShareBalance(),
+            partialSharesMinted,
+            "Cache should safely track the partial delivery"
+        );
+
+        // Assert totalAssets is still completely stable
+        // 1 share in cache (60k) + 60k pending = 120k total
+        assertEq(
+            ark.totalAssets(),
+            amount,
+            "NAV should not shift during partial clearance"
+        );
+    }
+
+    function test_EmergencyClearPendingDeposit_RescuesDeadlock() public {
+        uint256 amount = 1200000 * 1e6; // $1.2M USDC -> 20 shares
+        deal(USDC_ADDRESS, commander, amount);
+
+        vm.startPrank(commander);
+        usdc.forceApprove(address(ark), amount);
+        ark.board(amount, bytes(""));
+        vm.stopPrank();
+
+        // WisdomTree buys shares at the old price (e.g., 10 Shares for $600k)
+        // but only partially fills the order before the market closes.
+        uint256 partialSharesDelivered = 10e18;
+        wtToken.mint(address(ark), partialSharesDelivered);
+
+        // Suddenly, the Chainlink oracle price PLUMMETS (e.g. WTBTC drops to 20k)
+        oracle.setAnswer(20000 * 1e8);
+
+        // The Keeper wakes up and tries to clear the $600k partial fill.
+        // But because the oracle price dropped, $600k *should* buy 30 shares today.
+        // Since only 10 shares arrived, the slippage guardrail brutally rejects it.
+        vm.startPrank(keeper);
+
+        uint256 clearanceAttempt = 600000 * 1e6;
+        uint256 expectedSharesAtNewPrice = ark.sharesToAssets(clearanceAttempt); // Will be ~30 shares
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                WisdomTreeArk.SharesNotArrived.selector,
+                30e18, // Contract demands 30 shares based on today's cheap price
+                partialSharesDelivered // Only 10 arrived
+            )
+        );
+        ark.clearPendingDeposit(clearanceAttempt);
+        vm.stopPrank();
+
+        // The Governor verifies off-chain that $600k was legitimately
+        // spent to buy those 10 shares before the crash.
+
+        // First, ensure a rogue Keeper cannot call the emergency function
+        vm.startPrank(keeper);
+        vm.expectRevert(); // AccessControl revert
+        ark.emergencyClearPendingDeposit(clearanceAttempt);
+        vm.stopPrank();
+
+        // Governor executes the rescue
+        vm.startPrank(governor);
+
+        vm.expectEmit(false, false, false, true);
+        emit PendingDepositCleared(clearanceAttempt);
+
+        ark.emergencyClearPendingDeposit(clearanceAttempt);
+        vm.stopPrank();
+
+        assertEq(
+            ark.pendingDepositAssets(),
+            amount - clearanceAttempt,
+            "Pending queue should retain the remaining $600k"
+        );
+
+        // 2. The cache was forcefully sync'd to reality, capturing the 10 shares
+        assertEq(
+            ark.cachedShareBalance(),
+            partialSharesDelivered,
+            "Cache must hard-reset to physical balance to restore NAV parity"
+        );
+
+        // 3. The system is un-bricked and NAV calculates cleanly
+        uint256 rescuedTotalAssets = ark.totalAssets();
+
+        // 10 shares at $20k = $200k. Plus $600k still pending = $800k total.
+        uint256 expectedRescuedAssets = (10 * 20000 * 1e6) + (600000 * 1e6);
+        assertEq(
+            rescuedTotalAssets,
+            expectedRescuedAssets,
+            "NAV should perfectly reflect the new oracle reality + remaining pending USDC"
+        );
     }
 }

--- a/packages/core-contracts/test/arks/WisdomTreeArkFork.t.sol
+++ b/packages/core-contracts/test/arks/WisdomTreeArkFork.t.sol
@@ -56,11 +56,13 @@ contract WisdomTreeArkBaseForkTest is Test, IArkEvents, ArkTestBaseWhitelist {
 
         vm.startPrank(governor);
         Percentage sweepSlippage = Percentage.wrap(PERCENTAGE_FACTOR / 2);
+        Percentage depositSlippage = Percentage.wrap(PERCENTAGE_FACTOR / 2);
         ark = new WisdomTreeArk(
             TARGET_WALLET,
             SHARE_TOKEN,
             ORACLE,
             sweepSlippage,
+            depositSlippage,
             WisdomTreeArk.WTArkType.NonMoneyMarket,
             params
         );

--- a/packages/core-contracts/test/arks/WisdomTreeArkFork.t.sol
+++ b/packages/core-contracts/test/arks/WisdomTreeArkFork.t.sol
@@ -63,7 +63,6 @@ contract WisdomTreeArkBaseForkTest is Test, IArkEvents, ArkTestBaseWhitelist {
             ORACLE,
             sweepSlippage,
             depositSlippage,
-            WisdomTreeArk.WTArkType.NonMoneyMarket,
             params
         );
         accessManager.grantCommanderRole(address(ark), address(commander));

--- a/packages/deployment/config/index.test.json
+++ b/packages/deployment/config/index.test.json
@@ -143,91 +143,106 @@
             "oracle": "0x15FAf95ae42313E0CdAcb6f8076E866Eb6965961",
             "shareToken": "0x5096b85Ed11798fDdCB8b5CB27C399c04689c435",
             "targetWallet": "0x63a8bb98D70d0aC73460d22b6756528a087ecBf8",
-            "sweepSlippage": "500000000000000000"
+            "sweepSlippage": "500000000000000000",
+            "depositSlippage": "500000000000000000"
           },
           "WTSIX": {
             "oracle": "0x872E73cC259a025f089CEcF525cc657a9D521af3",
             "shareToken": "0xCf997c6A8DbdC1449e4dDE59Dbdf9cf6dA9d41c1",
             "sweepSlippage": "500000000000000000",
-            "targetWallet": "0xa6fe9331eae8DFfA4A4fE93c8B8544653856E882"
+            "targetWallet": "0xa6fe9331eae8DFfA4A4fE93c8B8544653856E882",
+            "depositSlippage": "500000000000000000"
           },
           "SPXUX": {
             "oracle": "0xEbE3ffFB369bE1ae32046D9bcC6a66cAbd19f079",
             "shareToken": "0xfec440FdF48860FF6E2265BD1ef9Cae8bB2cCe8a",
             "sweepSlippage": "500000000000000000",
-            "targetWallet": "0x79d83332fa4735a7B1A54728af3F578fAB97C9F1"
+            "targetWallet": "0x79d83332fa4735a7B1A54728af3F578fAB97C9F1",
+            "depositSlippage": "500000000000000000"
           },
           "TECHX": {
             "oracle": "0x64e433409041313496b6563C293Ebe466C6d3eFF",
             "shareToken": "0xF21cEDcEB91979C7877B98D4D60190215a5e6dC7",
             "sweepSlippage": "500000000000000000",
-            "targetWallet": "0x6859Bb46626a6E0b00558eA00159b8C14A36882B"
+            "targetWallet": "0x6859Bb46626a6E0b00558eA00159b8C14A36882B",
+            "depositSlippage": "500000000000000000"
           },
           "CRDT": {
             "oracle": "0x27137F39D8ecA6db037370EcDedFF3DFD01A229c",
             "shareToken": "0x10fe70382576f271caeF5C152266FB458eFB53fa",
             "sweepSlippage": "500000000000000000",
-            "targetWallet": "0xc24d277EEdc174b764C822a6965740f8C22CF95A"
+            "targetWallet": "0xc24d277EEdc174b764C822a6965740f8C22CF95A",
+            "depositSlippage": "500000000000000000"
           },
           "FLTTX": {
             "oracle": "0x48C1a4a76EBA4De411607C84F351F169086E786B",
             "shareToken": "0xcE6C2fDF6676e80F29D7f15B012A3a92cA3008C4",
             "sweepSlippage": "500000000000000000",
-            "targetWallet": "0xB0B673a031c80e0c9917DC73eA199ebA1e689fFC"
+            "targetWallet": "0xB0B673a031c80e0c9917DC73eA199ebA1e689fFC",
+            "depositSlippage": "500000000000000000"
           },
           "EPXC": {
             "oracle": "0xbf4d24f1A611C8C0F91A83D9EE33053330e223E0",
             "shareToken": "0xF20f050321DEb97F9180150E99f0e8133Aa71051",
             "sweepSlippage": "500000000000000000",
-            "targetWallet": "0xD358cE49Bc42e9e62746f584e107E989390de7AA"
+            "targetWallet": "0xD358cE49Bc42e9e62746f584e107E989390de7AA",
+            "depositSlippage": "500000000000000000"
           },
           "WTSYX": {
             "oracle": "0xe65D7c2FDECE1EcCeA471fCfe26D1cb397EBF831",
             "shareToken": "0xbb2ce6Adb794F1C9d6779DF86626bB6B4e485818",
             "sweepSlippage": "500000000000000000",
-            "targetWallet": "0x4b9cC5C587fe5Dbe6BF16F33BE948B8619F2E07E"
+            "targetWallet": "0x4b9cC5C587fe5Dbe6BF16F33BE948B8619F2E07E",
+            "depositSlippage": "500000000000000000"
           },
           "WTTSX": {
             "oracle": "0xC985c807B3Af1A69CD15CEF044599083B1DAc3Fd",
             "shareToken": "0x3403292bA55fFBFc5a655c75b757b00Fd57Ee51c",
             "sweepSlippage": "500000000000000000",
-            "targetWallet": "0x15A7A8a67Bc47F506a7eb30468e8533dD47299F7"
+            "targetWallet": "0x15A7A8a67Bc47F506a7eb30468e8533dD47299F7",
+            "depositSlippage": "500000000000000000"
           },
           "TIPSX": {
             "oracle": "0xb3f9A39dC589336BB5675733B54F92CEc593ABa0",
             "shareToken": "0x534A448cEb99D8Ce1bBBB556A5C13c6Fe79CA68c",
             "sweepSlippage": "500000000000000000",
-            "targetWallet": "0x81ce58FD1812cac9f60b20f3B39B30C39fF00d3d"
+            "targetWallet": "0x81ce58FD1812cac9f60b20f3B39B30C39fF00d3d",
+            "depositSlippage": "500000000000000000"
           },
           "WTLGX": {
             "oracle": "0x2B029Bf53dad10969D3f14107F21C9CaD59aAf12",
             "shareToken": "0x8A4AD570238002E49f9A2681398BF9C822302eee",
             "sweepSlippage": "500000000000000000",
-            "targetWallet": "0x5bC6710CcDC4074eAFac57f2e079Af761501d6fD"
+            "targetWallet": "0x5bC6710CcDC4074eAFac57f2e079Af761501d6fD",
+            "depositSlippage": "500000000000000000"
           },
           "WTSTX": {
             "oracle": "0x7f2A4bEdC1329b102AFf93bF205C7593CB103aeE",
             "shareToken": "0xE2ab0b91244c6e04bB92034849768ac9B954112c",
             "sweepSlippage": "500000000000000000",
-            "targetWallet": "0x8C00b161EB8A40E833703453235897173Fd4C47D"
+            "targetWallet": "0x8C00b161EB8A40E833703453235897173Fd4C47D",
+            "depositSlippage": "500000000000000000"
           },
           "EQTYX": {
             "oracle": "0x731EbC4EbFB2062e54872F3047A07D59375A61fE",
             "shareToken": "0xf4A3d6Da7E5F8A262B731DeEE62549C2c05035F5",
             "sweepSlippage": "500000000000000000",
-            "targetWallet": "0x377ED8f6980B95429Ad1720714839EDDefBE0bE6"
+            "targetWallet": "0x377ED8f6980B95429Ad1720714839EDDefBE0bE6",
+            "depositSlippage": "500000000000000000"
           },
           "MODRX": {
             "oracle": "0x0B65c6DdB6CfaeB65da422488ae493aeC5C1Ae00",
             "shareToken": "0x90A5aAD303D2170Bc846cd1237939Ac537F224A1",
             "sweepSlippage": "500000000000000000",
-            "targetWallet": "0x41A29dE80572D3896D83d87F52cFEDE369Cb11d9"
+            "targetWallet": "0x41A29dE80572D3896D83d87F52cFEDE369Cb11d9",
+            "depositSlippage": "500000000000000000"
           },
           "LNGVX": {
             "oracle": "0xe830FFc7D63a03284Ffc459aB19752CBE8E4d546",
             "shareToken": "0xC290Ff6eE86454B83a31C61010cd50DD53A56F24",
             "sweepSlippage": "500000000000000000",
-            "targetWallet": "0x52824473d93aCe8a21515526856dAEfd735d855A"
+            "targetWallet": "0x52824473d93aCe8a21515526856dAEfd735d855A",
+            "depositSlippage": "500000000000000000"
           }
         }
       },

--- a/packages/deployment/ignition/modules/arks/wisdom-tree-ark.ts
+++ b/packages/deployment/ignition/modules/arks/wisdom-tree-ark.ts
@@ -5,8 +5,8 @@ export function createWisdomTreeArkModule(moduleName: string) {
     const custodianWallet = m.getParameter<string>('targetWallet')
     const shareToken = m.getParameter<string>('shareToken')
     const oracle = m.getParameter<string>('oracle')
-    const arkType = m.getParameter<number>('arkType')
     const sweepSlippage = m.getParameter<string>('sweepSlippage')
+    const depositSlippage = m.getParameter<string>('depositSlippage')
     const name = m.getParameter<string>('name')
     const details = m.getParameter<string>('details')
     const configurationManager = m.getParameter<string>('configurationManager')
@@ -23,7 +23,7 @@ export function createWisdomTreeArkModule(moduleName: string) {
       shareToken,
       oracle,
       sweepSlippage,
-      arkType,
+      depositSlippage,
       {
         name,
         details,

--- a/packages/deployment/scripts/arks/deploy-wisdom-tree-ark.ts
+++ b/packages/deployment/scripts/arks/deploy-wisdom-tree-ark.ts
@@ -11,8 +11,8 @@ export type WisdomTreeArkParams = BaseArkParams & {
   shareToken: string
   oracle: string
   fundName: string
-  arkType?: number
-  sweepSlippage?: string
+  sweepSlippage: string
+  depositSlippage: string
 }
 
 export async function deployWisdomTreeArk(config: BaseConfig, params: WisdomTreeArkParams) {
@@ -28,8 +28,8 @@ export async function deployWisdomTreeArk(config: BaseConfig, params: WisdomTree
     shareToken,
     oracle,
     fundName,
-    arkType,
     sweepSlippage,
+    depositSlippage
   } = params
   const chainId = getChainId()
   const envLabel = isBummer ? 'staging_' : ''
@@ -64,7 +64,7 @@ export async function deployWisdomTreeArk(config: BaseConfig, params: WisdomTree
         shareToken,
         oracle,
         sweepSlippage: sweepSlippage ?? 0,
-        arkType: arkType ?? 0,
+        depositSlippage: depositSlippage ?? 0,
         name: arkName,
         details: JSON.stringify(arkDetails),
         configurationManager: config.deployedContracts.core.configurationManager.address,

--- a/packages/deployment/scripts/common/ark-deployment.ts
+++ b/packages/deployment/scripts/common/ark-deployment.ts
@@ -503,7 +503,7 @@ export async function deployArk(
         `WisdomTree fund '${fundName}' oracle`,
       )
       const sweepSlippage = wisdomtreeByToken[fundName].sweepSlippage
-      const arkType = arkConfig.params.arkType
+      const depositSlippage = wisdomtreeByToken[fundName].depositSlippage
       const ark = await deployWisdomTreeArk(config, {
         ...baseArkParams,
         fundName: fundName,
@@ -511,7 +511,7 @@ export async function deployArk(
         shareToken: shareToken,
         oracle: oracle,
         sweepSlippage: sweepSlippage,
-        arkType: arkType,
+        depositSlippage: depositSlippage,
       })
       deployedArk = ark
       break

--- a/packages/deployment/types/config-types.ts
+++ b/packages/deployment/types/config-types.ts
@@ -188,6 +188,7 @@ export interface BaseConfig {
           shareToken: string
           targetWallet: string
           sweepSlippage: string
+          depositSlippage: string
         }
       }
     }


### PR DESCRIPTION
**Keeper NAV Arbitrage via `clearPendingDeposit` Reordering**

- **Location**: `WisdomTreeArk.sol` & `FleetCommanderWhitelist.sol`
- **Description**: The Keeper can call `clearPendingDeposit` before off-chain shares actually arrive. This unilaterally crashes the Fleet's `totalAssets()` and Share Price.
- **Exploit**: An attacker (or the malicious keeper) can crash the NAV, deposit millions into the Fleet Commander to mint artificially cheap shares, wait for the off-chain shares to arrive (NAV recovers naturally), and withdraw — directly stealing millions from existing protocol LPs.