### PR TITLE
fix: RWA M-07

### DIFF
--- a/packages/core-contracts/src/contracts/FleetCommanderWhitelist.sol
+++ b/packages/core-contracts/src/contracts/FleetCommanderWhitelist.sol
@@ -471,7 +471,7 @@ contract FleetCommanderWhitelist is
     function setFeeType(
         FeeType newFeeType
     ) external onlyGovernor whenNotPaused {
-        _setFeeType(newFeeType, totalAssets(), super.totalSupply());
+        _setFeeType(newFeeType, tipJar(), totalAssets(), super.totalSupply());
     }
 
     /// @inheritdoc IFleetCommanderWhitelist

--- a/packages/core-contracts/src/contracts/FlexibleTipper.sol
+++ b/packages/core-contracts/src/contracts/FlexibleTipper.sol
@@ -79,32 +79,35 @@ abstract contract FlexibleTipper is IFlexibleTipper, Tipper {
 
     /**
      * @notice Sets the fee type and resets HWM to current assetsPerShare
-     * @param newFeeType The new fee type to set
+     * @param _newFeeType The new fee type to set
+     * @param _tipJar The address of the tip jar
      * @param _totalAssets The current total assets (passed to avoid re-computation)
      * @param _totalSupply The current total supply (passed to avoid re-computation)
      * @dev Resets HWM to current assetsPerShare to prevent "dead HWM" after drawdowns.
      *      The FeeTypeChanged event logs old and new HWM for on-chain auditability.
      */
     function _setFeeType(
-        FeeType newFeeType,
+        FeeType _newFeeType,
+        address _tipJar,
         uint256 _totalAssets,
         uint256 _totalSupply
     ) internal {
-        FeeType oldFeeType = feeType;
-        uint256 oldHWM = highWaterMark;
+        uint256 feeShares = _accrueTip(_tipJar, _totalSupply);
+        uint256 adjustedTotalSupply = _totalSupply + feeShares;
 
-        feeType = newFeeType;
+        uint256 oldHWM = highWaterMark;
 
         // Reset HWM to current assetsPerShare
         uint256 newHWM;
-        if (_totalSupply > 0) {
-            newHWM = (_totalAssets * 1e18) / _totalSupply;
+        if (adjustedTotalSupply > 0) {
+            newHWM = (_totalAssets * 1e18) / adjustedTotalSupply;
         } else {
             newHWM = 1e18; // Default 1:1 when no shares exist
         }
         highWaterMark = newHWM;
 
-        emit FeeTypeChanged(oldFeeType, newFeeType, oldHWM, newHWM);
+        emit FeeTypeChanged(feeType, _newFeeType, oldHWM, newHWM);
+        feeType = _newFeeType;
     }
 
     /**

--- a/packages/core-contracts/test/fleets/FlexibleTipper.t.sol
+++ b/packages/core-contracts/test/fleets/FlexibleTipper.t.sol
@@ -69,7 +69,7 @@ contract FlexibleTipperHarness is ERC4626, FlexibleTipper {
 
     // ---- Exposed setters for testing ----
     function setFeeType(FeeType newFeeType) external {
-        _setFeeType(newFeeType, totalAssets(), totalSupply());
+        _setFeeType(newFeeType, tipJar, totalAssets(), totalSupply());
     }
 
     function setPerformanceFeeRate(Percentage newRate) external {
@@ -566,6 +566,55 @@ contract FlexibleTipperTest is Test, ITipperEvents {
         uint256 actualTip = tipAfter - tipBefore;
 
         assertEq(preview, actualTip, "Preview should match actual tip minted");
+    }
+
+    function test_SetFeeType_AccruesTipAndUsesUpdatedSupplyForHWM() public {
+        // 1. Start in AUM mode (default state in setUp)
+        assertTrue(
+            vault.feeType() == IFlexibleTipper.FeeType.AUM,
+            "Should start in AUM mode"
+        );
+
+        // 2. Advance time by 1 year to build up a large pending AUM fee
+        vm.warp(block.timestamp + 365 days);
+
+        uint256 staleSupply = vault.totalSupply();
+        uint256 totalAssets = vault.totalAssets();
+
+        uint256 buggyInflatedHWM = (totalAssets * 1e18) / staleSupply;
+
+        uint256 tipJarBalanceBefore = IERC20(address(vault)).balanceOf(tipJar);
+
+        // 3. Change fee type. The fix should accrue the 1-year pending tip first.
+        vault.setFeeType(IFlexibleTipper.FeeType.BOTH);
+
+        uint256 tipJarBalanceAfter = IERC20(address(vault)).balanceOf(tipJar);
+
+        // Assert that the tip was actually minted during the state change
+        assertGt(
+            tipJarBalanceAfter,
+            tipJarBalanceBefore,
+            "Should have minted pending tips during setFeeType"
+        );
+
+        // 4. Verify the new HWM math
+        uint256 updatedSupply = vault.totalSupply();
+        uint256 expectedCorrectHWM = (totalAssets * 1e18) / updatedSupply;
+        uint256 actualHWM = vault.highWaterMark();
+
+        // Assert the HWM matches the post-accrual math
+        assertEq(
+            actualHWM,
+            expectedCorrectHWM,
+            "HWM must be calculated using the fully-diluted, post-accrual supply"
+        );
+
+        // Assert the actual HWM is strictly less than the buggy HWM
+        assertLt(
+            actualHWM,
+            buggyInflatedHWM,
+            "The fix should prevent the artificially inflated HWM"
+        );
     }
 }
 


### PR DESCRIPTION
**[M-07] `setFeeType` HWM Reset Uses Stale `totalSupply`**

- **Location**: `FlexibleTipper.sol`
- **Description**: When resetting the High-Water Mark, the math queries `super.totalSupply()`, which returns the raw ERC20 supply without first minting pending unaccrued AUM fee shares.
- **Exploit / Impact**: If significant AUM fees are pending, the raw supply is artificially small, making the resulting calculated Assets-Per-Share (and thus the new HWM) too high. This permanently penalizes the Treasury by establishing a fraudulently swollen baseline they must beat to earn future fees.