### PR TITLE
feat: add exit with permit2

### DIFF
--- a/packages/core-contracts/src/contracts/AdmiralsQuarters.sol
+++ b/packages/core-contracts/src/contracts/AdmiralsQuarters.sol
@@ -285,6 +285,79 @@ contract AdmiralsQuarters is
     }
 
     /// @inheritdoc IAdmiralsQuarters
+    function exitFleetWithPermit(
+        address owner,
+        address fleetCommander,
+        uint256 assets,
+        uint256 sharesApproval,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external payable onlyMulticall nonReentrant returns (uint256 shares) {
+        _validateFleetCommander(fleetCommander);
+        IFleetCommander fleet = IFleetCommander(fleetCommander);
+
+        // Approve AdmiralsQuarters to burn the exact amount of shares via EIP-2612 Permit
+        IERC20Permit(fleetCommander).permit(
+            owner,
+            address(this),
+            sharesApproval,
+            deadline,
+            v,
+            r,
+            s
+        );
+
+        assets = assets == 0 ? Constants.MAX_UINT256 : assets;
+
+        // Withdraw assets to the contract using the permit allowance from the owner
+        shares = fleet.withdraw(assets, address(this), owner);
+
+        emit FleetExited(owner, fleetCommander, assets, shares);
+    }
+
+    /// @inheritdoc IAdmiralsQuarters
+    function exitFleetWithPermit2(
+        address owner,
+        address fleetCommander,
+        uint256 assets,
+        ISignatureTransfer.PermitTransferFrom calldata permitData,
+        bytes calldata signature
+    ) external payable onlyMulticall nonReentrant returns (uint256 shares) {
+        _validateFleetCommander(fleetCommander);
+        IFleetCommander fleet = IFleetCommander(fleetCommander);
+
+        if (permitData.permitted.token != IERC20(fleetCommander))
+            revert InvalidToken();
+
+        uint256 sharesPulled = permitData.permitted.amount;
+
+        // Pull the shares from the owner to AdmiralsQuarters via Permit2
+        ISignatureTransfer(PERMIT2).permitTransferFrom(
+            permitData,
+            ISignatureTransfer.SignatureTransferDetails({
+                to: address(this),
+                requestedAmount: sharesPulled
+            }),
+            owner,
+            signature
+        );
+
+        assets = assets == 0 ? Constants.MAX_UINT256 : assets;
+
+        // Since the contract now holds the shares, burn from address(this)
+        shares = fleet.withdraw(assets, address(this), address(this));
+
+        // Refund any excess shares that were pulled but not burned (if the user requested exact assets)
+        if (sharesPulled > shares) {
+            IERC20(fleetCommander).safeTransfer(owner, sharesPulled - shares);
+        }
+
+        emit FleetExited(owner, fleetCommander, assets, shares);
+    }
+
+    /// @inheritdoc IAdmiralsQuarters
     function stake(
         address fleetCommander,
         uint256 shares

--- a/packages/core-contracts/src/contracts/AdmiralsQuarters.sol
+++ b/packages/core-contracts/src/contracts/AdmiralsQuarters.sol
@@ -285,51 +285,18 @@ contract AdmiralsQuarters is
     }
 
     /// @inheritdoc IAdmiralsQuarters
-    function exitFleetWithPermit(
-        address owner,
-        address fleetCommander,
-        uint256 assets,
-        uint256 sharesApproval,
-        uint256 deadline,
-        uint8 v,
-        bytes32 r,
-        bytes32 s
-    ) external payable onlyMulticall nonReentrant returns (uint256 shares) {
-        _validateFleetCommander(fleetCommander);
-        IFleetCommander fleet = IFleetCommander(fleetCommander);
-
-        // Approve AdmiralsQuarters to burn the exact amount of shares via EIP-2612 Permit
-        IERC20Permit(fleetCommander).permit(
-            owner,
-            address(this),
-            sharesApproval,
-            deadline,
-            v,
-            r,
-            s
-        );
-
-        assets = assets == 0 ? Constants.MAX_UINT256 : assets;
-
-        // Withdraw assets to the contract using the permit allowance from the owner
-        shares = fleet.withdraw(assets, address(this), owner);
-
-        emit FleetExited(owner, fleetCommander, assets, shares);
-    }
-
-    /// @inheritdoc IAdmiralsQuarters
     function exitFleetWithPermit2(
         address owner,
         address fleetCommander,
-        uint256 assets,
         ISignatureTransfer.PermitTransferFrom calldata permitData,
         bytes calldata signature
-    ) external payable onlyMulticall nonReentrant returns (uint256 shares) {
+    ) external payable onlyMulticall nonReentrant returns (uint256 assets) {
         _validateFleetCommander(fleetCommander);
         IFleetCommander fleet = IFleetCommander(fleetCommander);
 
-        if (permitData.permitted.token != IERC20(fleetCommander))
+        if (permitData.permitted.token != IERC20(fleetCommander)) {
             revert InvalidToken();
+        }
 
         uint256 sharesPulled = permitData.permitted.amount;
 
@@ -344,17 +311,10 @@ contract AdmiralsQuarters is
             signature
         );
 
-        assets = assets == 0 ? Constants.MAX_UINT256 : assets;
+        // Redeem the shares for assets and send them to the owner
+        assets = fleet.redeem(sharesPulled, owner, address(this));
 
-        // Since the contract now holds the shares, burn from address(this)
-        shares = fleet.withdraw(assets, address(this), address(this));
-
-        // Refund any excess shares that were pulled but not burned (if the user requested exact assets)
-        if (sharesPulled > shares) {
-            IERC20(fleetCommander).safeTransfer(owner, sharesPulled - shares);
-        }
-
-        emit FleetExited(owner, fleetCommander, assets, shares);
+        emit FleetExited(owner, fleetCommander, sharesPulled, assets);
     }
 
     /// @inheritdoc IAdmiralsQuarters

--- a/packages/core-contracts/src/contracts/AdmiralsQuarters.sol
+++ b/packages/core-contracts/src/contracts/AdmiralsQuarters.sol
@@ -299,6 +299,7 @@ contract AdmiralsQuarters is
         }
 
         uint256 sharesPulled = permitData.permitted.amount;
+        if (sharesPulled == 0) revert ZeroAmount();
 
         // Pull the shares from the owner to AdmiralsQuarters via Permit2
         ISignatureTransfer(PERMIT2).permitTransferFrom(
@@ -314,7 +315,7 @@ contract AdmiralsQuarters is
         // Redeem the shares for assets and send them to the owner
         assets = fleet.redeem(sharesPulled, owner, address(this));
 
-        emit FleetExited(owner, fleetCommander, sharesPulled, assets);
+        emit FleetExited(owner, fleetCommander, assets, sharesPulled);
     }
 
     /// @inheritdoc IAdmiralsQuarters

--- a/packages/core-contracts/src/interfaces/IAdmiralsQuarters.sol
+++ b/packages/core-contracts/src/interfaces/IAdmiralsQuarters.sol
@@ -15,29 +15,6 @@ interface IAdmiralsQuarters is
     IAdmiralsQuartersErrors
 {
     /**
-     * @notice Enters a fleet using an ERC-2612 permit signature
-     * @param owner The address providing the tokens and receiving the shares
-     * @param fleetCommander The address of the fleet commander
-     * @param assets The amount of tokens to deposit
-     * @param referralCode The referral code (empty for no referral)
-     * @param deadline The deadline beyond which the permit signature is invalid
-     * @param v The recovery byte of the signature
-     * @param r Half of the ECDSA signature pair
-     * @param s Half of the ECDSA signature pair
-     * @return shares The amount of shares received
-     */
-    function enterFleetWithPermit(
-        address owner,
-        address fleetCommander,
-        uint256 assets,
-        bytes calldata referralCode,
-        uint256 deadline,
-        uint8 v,
-        bytes32 r,
-        bytes32 s
-    ) external payable returns (uint256 shares);
-
-    /**
      * @notice Enters a fleet using a Uniswap Permit2 signature transfer
      * @param owner The address providing the tokens and receiving the shares
      * @param fleetCommander The address of the fleet commander
@@ -57,8 +34,29 @@ interface IAdmiralsQuarters is
     ) external payable returns (uint256 shares);
 
     /**
-     *
-     **
+     * @notice Enters a fleet using an ERC-2612 permit signature for tokens
+     * @param owner The address providing the tokens and receiving the shares
+     * @param fleetCommander The address of the fleet commander
+     * @param assets The amount of tokens to deposit
+     * @param referralCode The referral code (empty for no referral)
+     * @param deadline The deadline for the permit signature
+     * @param v The recovery byte of the signature
+     * @param r Half of the ECDSA signature pair
+     * @param s Half of the ECDSA signature pair
+     * @return shares The amount of shares received
+     */
+    function enterFleetWithPermit(
+        address owner,
+        address fleetCommander,
+        uint256 assets,
+        bytes calldata referralCode,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external payable returns (uint256 shares);
+
+    /**
      * @notice Deposits tokens into the contract
      * @param asset The token to be deposited
      * @param amount The amount of tokens to deposit
@@ -140,46 +138,20 @@ interface IAdmiralsQuarters is
     ) external payable returns (uint256 shares);
 
     /**
-     * @notice Exits a fleet using an ERC-2612 permit signature for shares approval
-     * @param owner The address providing the shares and receiving the assets
-     * @param fleetCommander The address of the fleet commander
-     * @param assets The amount of assets to withdraw (0 for max)
-     * @param sharesApproval The maximum amount of shares approved via permit
-     * @param deadline The deadline beyond which the permit signature is invalid
-     * @param v The recovery byte of the signature
-     * @param r Half of the ECDSA signature pair
-     * @param s Half of the ECDSA signature pair
-     * @return shares The amount of shares burned
-     * @dev Emits a FleetExited event
-     */
-    function exitFleetWithPermit(
-        address owner,
-        address fleetCommander,
-        uint256 assets,
-        uint256 sharesApproval,
-        uint256 deadline,
-        uint8 v,
-        bytes32 r,
-        bytes32 s
-    ) external payable returns (uint256 shares);
-
-    /**
      * @notice Exits a fleet using a Uniswap Permit2 signature transfer for shares
      * @param owner The address providing the shares and receiving the assets
      * @param fleetCommander The address of the fleet commander
-     * @param assets The amount of assets to withdraw (0 for max)
      * @param permitData The permit transfer from details (token, amount, nonce, deadline)
      * @param signature The Permit2 signature from the user
-     * @return shares The amount of shares burned
+     * @return assets The amount of assets received
      * @dev Emits a FleetExited event
      */
     function exitFleetWithPermit2(
         address owner,
         address fleetCommander,
-        uint256 assets,
         ISignatureTransfer.PermitTransferFrom calldata permitData,
         bytes calldata signature
-    ) external payable returns (uint256 shares);
+    ) external payable returns (uint256 assets);
 
     /**
      * @notice Performs a token swap using 1inch Router

--- a/packages/core-contracts/src/interfaces/IAdmiralsQuarters.sol
+++ b/packages/core-contracts/src/interfaces/IAdmiralsQuarters.sol
@@ -140,6 +140,48 @@ interface IAdmiralsQuarters is
     ) external payable returns (uint256 shares);
 
     /**
+     * @notice Exits a fleet using an ERC-2612 permit signature for shares approval
+     * @param owner The address providing the shares and receiving the assets
+     * @param fleetCommander The address of the fleet commander
+     * @param assets The amount of assets to withdraw (0 for max)
+     * @param sharesApproval The maximum amount of shares approved via permit
+     * @param deadline The deadline beyond which the permit signature is invalid
+     * @param v The recovery byte of the signature
+     * @param r Half of the ECDSA signature pair
+     * @param s Half of the ECDSA signature pair
+     * @return shares The amount of shares burned
+     * @dev Emits a FleetExited event
+     */
+    function exitFleetWithPermit(
+        address owner,
+        address fleetCommander,
+        uint256 assets,
+        uint256 sharesApproval,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external payable returns (uint256 shares);
+
+    /**
+     * @notice Exits a fleet using a Uniswap Permit2 signature transfer for shares
+     * @param owner The address providing the shares and receiving the assets
+     * @param fleetCommander The address of the fleet commander
+     * @param assets The amount of assets to withdraw (0 for max)
+     * @param permitData The permit transfer from details (token, amount, nonce, deadline)
+     * @param signature The Permit2 signature from the user
+     * @return shares The amount of shares burned
+     * @dev Emits a FleetExited event
+     */
+    function exitFleetWithPermit2(
+        address owner,
+        address fleetCommander,
+        uint256 assets,
+        ISignatureTransfer.PermitTransferFrom calldata permitData,
+        bytes calldata signature
+    ) external payable returns (uint256 shares);
+
+    /**
      * @notice Performs a token swap using 1inch Router
      * @param fromToken The token to swap from
      * @param toToken The token to swap to

--- a/packages/core-contracts/test/admiralsQuarters/AdmiralsQuarters.permit.t.sol
+++ b/packages/core-contracts/test/admiralsQuarters/AdmiralsQuarters.permit.t.sol
@@ -222,28 +222,18 @@ contract AdmiralsQuartersPermitTest is AdmiralsQuartersTest {
 
         // 4. Solver calls exitFleetWithPermit2 via multicall
         vm.startPrank(solver);
-        bytes[] memory calls = new bytes[](2);
+        bytes[] memory calls = new bytes[](1);
         calls[0] = abi.encodeCall(
             admiralsQuarters.exitFleetWithPermit2,
-            (
-                owner,
-                address(usdcFleet),
-                amount, // requested assets
-                permit,
-                signature
-            )
-        );
-        calls[1] = abi.encodeCall(
-            admiralsQuarters.withdrawTokens,
-            (IERC20(USDC_ADDRESS), 0) // Withdraw all to msg.sender
+            (owner, address(usdcFleet), permit, signature)
         );
 
         vm.expectEmit(true, true, true, true);
         emit IAdmiralsQuartersEvents.FleetExited(
             owner,
             address(usdcFleet),
-            amount,
-            shares
+            shares,
+            amount
         );
 
         admiralsQuarters.multicall(calls);
@@ -252,15 +242,10 @@ contract AdmiralsQuartersPermitTest is AdmiralsQuartersTest {
         // 5. Verify results
         assertEq(usdcFleet.balanceOf(owner), 0, "Shares should be burned");
         assertApproxEqAbs(
-            IERC20(USDC_ADDRESS).balanceOf(solver),
-            amount,
-            2,
-            "Solver should have received the USDC"
-        );
-        assertEq(
             IERC20(USDC_ADDRESS).balanceOf(owner),
-            9000e6, // 10000 - 1000
-            "Owner should have 9000 USDC left"
+            10000e6,
+            2,
+            "Owner should have received the USDC back"
         );
         assertEq(
             IERC20(address(usdcFleet)).balanceOf(address(admiralsQuarters)),
@@ -271,6 +256,150 @@ contract AdmiralsQuartersPermitTest is AdmiralsQuartersTest {
             IERC20(USDC_ADDRESS).balanceOf(address(admiralsQuarters)),
             0,
             "AQ should have no leftover assets"
+        );
+    }
+
+    function test_ExitSwapEnter_Permit2() public {
+        uint256 usdcAmount = 1000e6;
+        uint256 deadline = block.timestamp + 100;
+
+        // 1. Setup: Owner enters USDC fleet to get shares
+        vm.startPrank(owner);
+        IERC20(USDC_ADDRESS).approve(address(usdcFleet), usdcAmount);
+        uint256 usdcShares = usdcFleet.deposit(usdcAmount, owner);
+        assertEq(usdcFleet.balanceOf(owner), usdcShares);
+
+        // Enable transfers for usdcFleet (needed for Permit2 transferFrom)
+        vm.stopPrank();
+        vm.prank(governor);
+        usdcFleet.setFleetTokenTransferability();
+        vm.startPrank(owner);
+
+        // 2. Setup approvals for Permit2 and AQ
+        IERC20(address(usdcFleet)).approve(PERMIT2, type(uint256).max);
+        IERC20(USDC_ADDRESS).approve(PERMIT2, type(uint256).max);
+        IERC20(DAI_ADDRESS).approve(PERMIT2, type(uint256).max);
+        // Pre-approve AQ for depositTokens call (this is the "round trip" part)
+        IERC20(USDC_ADDRESS).approve(
+            address(admiralsQuarters),
+            type(uint256).max
+        );
+        IERC20(DAI_ADDRESS).approve(
+            address(admiralsQuarters),
+            type(uint256).max
+        );
+        vm.stopPrank();
+
+        // 3. Prepare Sig 1: Exit USDC Fleet
+        ISignatureTransfer.PermitTransferFrom
+            memory exitPermit = ISignatureTransfer.PermitTransferFrom({
+                permitted: ISignatureTransfer.TokenPermissions({
+                    token: IERC20(address(usdcFleet)),
+                    amount: usdcShares
+                }),
+                nonce: 0,
+                deadline: deadline
+            });
+        bytes memory exitSig = _getPermit2Signature(
+            exitPermit,
+            address(admiralsQuarters),
+            ownerPrivateKey
+        );
+
+        // 4. Prepare Swap: USDC -> DAI
+        uint256 minDaiAmount = 990e18;
+        bytes memory usdcToDaiSwap = encodeUnoswapData(
+            USDC_ADDRESS,
+            usdcAmount,
+            minDaiAmount,
+            UNISWAP_USDC_DAI_V3_POOL,
+            Protocol.UniswapV3,
+            false,
+            false,
+            false,
+            false
+        );
+
+        // 5. Prepare Sig 2: Enter DAI Fleet
+        // We expect approx usdcAmount in DAI (since it's a stable swap)
+        // Let's use a safe amount for the permit
+        uint256 expectedDai = 995e18;
+        ISignatureTransfer.PermitTransferFrom
+            memory enterPermit = ISignatureTransfer.PermitTransferFrom({
+                permitted: ISignatureTransfer.TokenPermissions({
+                    token: IERC20(DAI_ADDRESS),
+                    amount: expectedDai
+                }),
+                nonce: 1, // Different nonce for second permit
+                deadline: deadline
+            });
+        bytes memory enterSig = _getPermit2Signature(
+            enterPermit,
+            address(admiralsQuarters),
+            ownerPrivateKey
+        );
+
+        // 6. Execute Multicall
+        vm.startPrank(owner);
+        bytes[] memory calls = new bytes[](5);
+
+        // Step A: Exit USDC Fleet -> USDC to Owner
+        calls[0] = abi.encodeCall(
+            admiralsQuarters.exitFleetWithPermit2,
+            (owner, address(usdcFleet), exitPermit, exitSig)
+        );
+
+        // Step B: Deposit USDC to AQ for swap
+        calls[1] = abi.encodeCall(
+            admiralsQuarters.depositTokens,
+            (IERC20(USDC_ADDRESS), usdcAmount)
+        );
+
+        // Step C: Swap USDC to DAI
+        calls[2] = abi.encodeCall(
+            admiralsQuarters.swap,
+            (
+                IERC20(USDC_ADDRESS),
+                IERC20(DAI_ADDRESS),
+                usdcAmount,
+                minDaiAmount,
+                usdcToDaiSwap
+            )
+        );
+
+        // Step D: Withdraw DAI to Owner (so enterFleetWithPermit2 can pull it)
+        calls[3] = abi.encodeCall(
+            admiralsQuarters.withdrawTokens,
+            (IERC20(DAI_ADDRESS), expectedDai)
+        );
+
+        // Step E: Enter DAI Fleet -> pulls from Owner
+        calls[4] = abi.encodeCall(
+            admiralsQuarters.enterFleetWithPermit2,
+            (owner, address(daiFleet), expectedDai, "", enterPermit, enterSig)
+        );
+
+        admiralsQuarters.multicall(calls);
+        vm.stopPrank();
+
+        // 7. Verify results
+        assertEq(
+            usdcFleet.balanceOf(owner),
+            0,
+            "USDC Fleet shares should be gone"
+        );
+        uint256 daiShares = daiFleet.balanceOf(owner);
+        assertApproxEqAbs(
+            daiShares,
+            expectedDai,
+            1e18,
+            "Should have received DAI Fleet shares"
+        );
+
+        assertEq(
+            IERC20(USDC_ADDRESS).balanceOf(address(admiralsQuarters)),
+            0,
+            "AQ USDC balance 0"
         );
     }
 

--- a/packages/core-contracts/test/admiralsQuarters/AdmiralsQuarters.permit.t.sol
+++ b/packages/core-contracts/test/admiralsQuarters/AdmiralsQuarters.permit.t.sol
@@ -183,6 +183,97 @@ contract AdmiralsQuartersPermitTest is AdmiralsQuartersTest {
         );
     }
 
+    function test_exitFleetWithPermit2() public {
+        uint256 amount = 1000e6;
+        uint256 deadline = block.timestamp + 100;
+
+        // 1. Setup: Owner enters fleet to get shares
+        vm.startPrank(owner);
+        IERC20(USDC_ADDRESS).approve(address(usdcFleet), amount);
+        uint256 shares = usdcFleet.deposit(amount, owner);
+        assertEq(usdcFleet.balanceOf(owner), shares);
+
+        // Enable transfers for usdcFleet (needed for Permit2 transferFrom)
+        vm.stopPrank();
+        vm.prank(governor);
+        usdcFleet.setFleetTokenTransferability();
+        vm.startPrank(owner);
+
+        // 2. Owner approves Permit2 for shares (needed for Permit2 to work)
+        IERC20(address(usdcFleet)).approve(PERMIT2, type(uint256).max);
+        vm.stopPrank();
+
+        // 3. User signs Permit2 transfer for shares
+        ISignatureTransfer.PermitTransferFrom memory permit = ISignatureTransfer
+            .PermitTransferFrom({
+                permitted: ISignatureTransfer.TokenPermissions({
+                    token: IERC20(address(usdcFleet)),
+                    amount: shares
+                }),
+                nonce: 0,
+                deadline: deadline
+            });
+
+        bytes memory signature = _getPermit2Signature(
+            permit,
+            address(admiralsQuarters),
+            ownerPrivateKey
+        );
+
+        // 4. Solver calls exitFleetWithPermit2 via multicall
+        vm.startPrank(solver);
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = abi.encodeCall(
+            admiralsQuarters.exitFleetWithPermit2,
+            (
+                owner,
+                address(usdcFleet),
+                amount, // requested assets
+                permit,
+                signature
+            )
+        );
+        calls[1] = abi.encodeCall(
+            admiralsQuarters.withdrawTokens,
+            (IERC20(USDC_ADDRESS), 0) // Withdraw all to msg.sender
+        );
+
+        vm.expectEmit(true, true, true, true);
+        emit IAdmiralsQuartersEvents.FleetExited(
+            owner,
+            address(usdcFleet),
+            amount,
+            shares
+        );
+
+        admiralsQuarters.multicall(calls);
+        vm.stopPrank();
+
+        // 5. Verify results
+        assertEq(usdcFleet.balanceOf(owner), 0, "Shares should be burned");
+        assertApproxEqAbs(
+            IERC20(USDC_ADDRESS).balanceOf(solver),
+            amount,
+            2,
+            "Solver should have received the USDC"
+        );
+        assertEq(
+            IERC20(USDC_ADDRESS).balanceOf(owner),
+            9000e6, // 10000 - 1000
+            "Owner should have 9000 USDC left"
+        );
+        assertEq(
+            IERC20(address(usdcFleet)).balanceOf(address(admiralsQuarters)),
+            0,
+            "AQ should have no leftover shares"
+        );
+        assertEq(
+            IERC20(USDC_ADDRESS).balanceOf(address(admiralsQuarters)),
+            0,
+            "AQ should have no leftover assets"
+        );
+    }
+
     // Helper to get USDC nonce
     function _getUSDCNonce(
         address token,


### PR DESCRIPTION
## Description
[Provide a brief description of the changes in this PR]

## Changes
- [List the main changes made in bullet points]

## Benefits
1. [List the benefits of these changes]
2. 
3. 

## Testing
[Describe how these changes were tested or how they can be tested]

## Next steps
- [List any follow-up actions or considerations]

## Additional Notes
[Any additional information, context, or notes for reviewers]

Please review and provide any feedback or suggestions for improvement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Permit2-based fleet exit: users can exit fleets via Permit2 signature transfers.
  * Swapped/clarified permit method signatures so entry functions distinctly support ERC-2612 vs Permit2 flows.

* **Tests**
  * Added tests for Permit2 fleet exit and a multi-step exit→swap→enter flow using Permit2 signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->