### PR TITLE
chore: migrate subgraph to mainnet, enable grafting, and add fallback…

### DIFF
--- a/packages/summer-earn-gov-validator/next.config.js
+++ b/packages/summer-earn-gov-validator/next.config.js
@@ -7,9 +7,9 @@ const __dirname = path.dirname(__filename)
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  // experimental: {
-  //   outputFileTracingRoot: path.join(__dirname, '../../'),
-  // },
+  experimental: {
+    outputFileTracingRoot: path.join(__dirname, '../../'),
+  },
 }
 
 export default nextConfig;

--- a/packages/summer-earn-gov-validator/next.config.js
+++ b/packages/summer-earn-gov-validator/next.config.js
@@ -7,9 +7,9 @@ const __dirname = path.dirname(__filename)
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  experimental: {
-    outputFileTracingRoot: path.join(__dirname, '../../'),
-  },
+  // experimental: {
+  //   outputFileTracingRoot: path.join(__dirname, '../../'),
+  // },
 }
 
 export default nextConfig;

--- a/packages/summer-earn-protocol-subgraph/config/mainnet.json
+++ b/packages/summer-earn-protocol-subgraph/config/mainnet.json
@@ -10,6 +10,6 @@
   "summer-staking-v2-staging-start-block": 301218468,
   "interval-handler-block-interval": 30,
   "enable-grafting": false,
-  "grafting-base": "QmfJ7fMYgeMpTV3pRHbDbmQvuoMyDytc5ipxg5mJZPbSrP",
-  "grafting-block": "24533626"
+  "grafting-base": "QmbDPxVraF2DfgxgbHDuwGSK5WmQMhuNbk9jHHeNL7iB78",
+  "grafting-block": "25066000"
 }

--- a/packages/summer-earn-protocol-subgraph/package.json
+++ b/packages/summer-earn-protocol-subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@summerfi/summer-earn-protocol-subgraph",
-  "version": "1.8.0-admin-actions",
+  "version": "1.9.0-withdrawable-assets-fallback",
   "scripts": {
     "prepare:arbitrum": "mustache config/arbitrum.json subgraph.template.yaml > subgraph.yaml ",
     "prepare:base": "mustache config/base.json subgraph.template.yaml > subgraph.yaml ",

--- a/packages/summer-earn-protocol-subgraph/src/utils/vault.ts
+++ b/packages/summer-earn-protocol-subgraph/src/utils/vault.ts
@@ -28,7 +28,11 @@ export function getVaultDetails(vault: Vault, block: ethereum.Block): VaultDetai
       ? constants.BigDecimalConstants.ONE
       : totalAssets.toBigDecimal().div(totalSupply.toBigDecimal())
   const outputTokenPriceUSD = pricePerShare.times(inputTokenPriceUSD.price)
-  const withdrawableAssets = vaultContract.withdrawableTotalAssets()
+  const maybeWithdrawableAssets = vaultContract.try_withdrawableTotalAssets()
+
+  const withdrawableAssets = maybeWithdrawableAssets.reverted
+    ? constants.BigIntConstants.ZERO
+    : maybeWithdrawableAssets.value
   const withdrawableAssetsNormalized = formatAmount(
     withdrawableAssets,
     BigInt.fromI32(inputToken.decimals),

--- a/packages/summer-earn-protocol-subgraph/subgraph.yaml
+++ b/packages/summer-earn-protocol-subgraph/subgraph.yaml
@@ -1,14 +1,19 @@
 specVersion: 0.0.8
 schema:
   file: ./schema.graphql 
+features:
+  - grafting
+graft:
+  base: QmbDPxVraF2DfgxgbHDuwGSK5WmQMhuNbk9jHHeNL7iB78
+  block: 25066000
 dataSources:
   - kind: ethereum/contract
     name: SummerStakingV2
-    network: hyperevm
+    network: mainnet
     source:
       abi: SummerStakingV2
       address: "0x0000000000000000000000000000000000000000"
-      startBlock: 24626300
+      startBlock: 301218468
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -28,11 +33,11 @@ dataSources:
       file: ./src/mappings/summerStakingV2.ts
   - kind: ethereum/contract
     name: SummerStakingV2Staging
-    network: hyperevm
+    network: mainnet
     source:
       abi: SummerStakingV2
       address: "0x0000000000000000000000000000000000000000"
-      startBlock: 24626300
+      startBlock: 301218468
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -52,11 +57,11 @@ dataSources:
       file: ./src/mappings/summerStakingV2.ts      
   - kind: ethereum/contract
     name: HarborCommand
-    network: hyperevm
+    network: mainnet
     source:
       abi: HarborCommand
-      address: "0x5CD5D7e3A1b604E0EdeDc4A2343b312729e09E3F"
-      startBlock: 24626300
+      address: "0x09eb323dBFECB43fd746c607A9321dACdfB0140F"
+      startBlock: 21745351
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -106,15 +111,15 @@ dataSources:
         - handler: handleInterval
           filter:
             kind: polling
-            every: 600 
+            every: 30 
       file: ./src/mappings/harborCommand.ts
   - kind: ethereum/contract
     name: GovernanceRewardsManager
-    network: hyperevm
+    network: mainnet
     source:
       abi: GovernanceRewardsManager
-      address: "0x0000000000000000000000000000000000000000"
-      startBlock: 24626300
+      address: "0xDe61A0a49f48e108079bdE73caeA56E87FfeEF92"
+      startBlock: 21745351
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -177,7 +182,7 @@ dataSources:
 templates:
   - kind: ethereum/contract
     name: FleetCommanderTemplate
-    network: hyperevm
+    network: mainnet
     source:
       abi: FleetCommander
     mapping:
@@ -265,7 +270,7 @@ templates:
       file: ./src/mappings/fleetCommander.ts
   - kind: ethereum/contract
     name: ArkTemplate
-    network: hyperevm
+    network: mainnet
     source:
       abi: Ark
     mapping:
@@ -328,7 +333,7 @@ templates:
       file: ./src/mappings/ark.ts
   - kind: ethereum/contract
     name: FleetCommanderRewardsManagerTemplate
-    network: hyperevm
+    network: mainnet
     source:
       abi: FleetCommanderRewardsManager
     mapping:


### PR DESCRIPTION
if `fleet.withdrawableAssets()` reverts -> report `0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 1.9.0-withdrawable-assets-fallback
  * Migrated subgraph configuration and contract data sources to mainnet
  * Updated grafting configuration parameters

* **Improvements**
  * Enhanced vault asset calculation with improved fallback handling to ensure withdrawable assets default safely when unavailable

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OasisDEX/summer-earn-protocol/pull/786)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->