### PR TITLE
fix(AdmiralsQuarters): validate input vault on moveFromERC4626ToAdmiralsQuarters

### DIFF
--- a/packages/core-contracts/src/contracts/AdmiralsQuarters.sol
+++ b/packages/core-contracts/src/contracts/AdmiralsQuarters.sol
@@ -645,6 +645,8 @@ contract AdmiralsQuarters is
         address vault,
         uint256 shares
     ) external onlyMulticall nonReentrant {
+        _validateToken(IERC20(vault));
+
         IERC4626 vaultToken = IERC4626(vault);
 
         // Get actual shares if 0 was passed

--- a/packages/core-contracts/src/contracts/AdmiralsQuartersWhitelist.sol
+++ b/packages/core-contracts/src/contracts/AdmiralsQuartersWhitelist.sol
@@ -462,6 +462,8 @@ contract AdmiralsQuartersWhitelist is
         address vault,
         uint256 shares
     ) external onlyMulticall nonReentrant {
+        _validateToken(IERC20(vault));
+
         IERC4626 vaultToken = IERC4626(vault);
 
         // Get actual shares if 0 was passed

--- a/packages/core-contracts/test/admiralsQuarters/AdmiralsQuarters.import.t.sol
+++ b/packages/core-contracts/test/admiralsQuarters/AdmiralsQuarters.import.t.sol
@@ -397,23 +397,37 @@ contract AdmiralsQuartersImportTest is
 
     function test_ImportReverts() public {
         vm.startPrank(user1);
+        bytes[] memory calls = new bytes[](1);
 
         // Test invalid token addresses
+        calls[0] = abi.encodeCall(
+            admiralsQuarters.moveFromCompoundToAdmiralsQuarters,
+            (address(0), 1000)
+        );
         vm.expectRevert();
-        admiralsQuarters.moveFromCompoundToAdmiralsQuarters(address(0), 1000);
+        admiralsQuarters.multicall(calls);
 
+        calls[0] = abi.encodeCall(
+            admiralsQuarters.moveFromAaveToAdmiralsQuarters,
+            (address(0), 1000)
+        );
         vm.expectRevert();
-        admiralsQuarters.moveFromAaveToAdmiralsQuarters(address(0), 1000);
+        admiralsQuarters.multicall(calls);
 
-        vm.expectRevert();
-        admiralsQuarters.moveFromERC4626ToAdmiralsQuarters(address(0), 1000);
+        calls[0] = abi.encodeCall(
+            admiralsQuarters.moveFromERC4626ToAdmiralsQuarters,
+            (address(0), 1000)
+        );
+        vm.expectRevert(abi.encodeWithSignature("InvalidToken()"));
+        admiralsQuarters.multicall(calls);
 
         // Test insufficient balance
-        vm.expectRevert();
-        admiralsQuarters.moveFromCompoundToAdmiralsQuarters(
-            CUSDC_ADDRESS,
-            1000
+        calls[0] = abi.encodeCall(
+            admiralsQuarters.moveFromCompoundToAdmiralsQuarters,
+            (CUSDC_ADDRESS, 1000)
         );
+        vm.expectRevert();
+        admiralsQuarters.multicall(calls);
 
         vm.stopPrank();
     }

--- a/packages/core-contracts/test/admiralsQuarters/AdmiralsQuartersWhitelist.t.sol
+++ b/packages/core-contracts/test/admiralsQuarters/AdmiralsQuartersWhitelist.t.sol
@@ -738,24 +738,37 @@ contract AdmiralsQuartersWhitelistTest is
 
     function test_ImportReverts() public {
         vm.startPrank(user1);
+        bytes[] memory calls = new bytes[](1);
 
         // Test invalid token addresses
-        // Since safeTransferFrom or standard operations on 0x0 will fail.
+        calls[0] = abi.encodeCall(
+            admiralsQuarters.moveFromCompoundToAdmiralsQuarters,
+            (address(0), 1000)
+        );
         vm.expectRevert();
-        admiralsQuarters.moveFromCompoundToAdmiralsQuarters(address(0), 1000);
+        admiralsQuarters.multicall(calls);
 
+        calls[0] = abi.encodeCall(
+            admiralsQuarters.moveFromAaveToAdmiralsQuarters,
+            (address(0), 1000)
+        );
         vm.expectRevert();
-        admiralsQuarters.moveFromAaveToAdmiralsQuarters(address(0), 1000);
+        admiralsQuarters.multicall(calls);
 
-        vm.expectRevert();
-        admiralsQuarters.moveFromERC4626ToAdmiralsQuarters(address(0), 1000);
+        calls[0] = abi.encodeCall(
+            admiralsQuarters.moveFromERC4626ToAdmiralsQuarters,
+            (address(0), 1000)
+        );
+        vm.expectRevert(abi.encodeWithSignature("InvalidToken()"));
+        admiralsQuarters.multicall(calls);
 
         // Test insufficient balance (using CUSDC_ADDRESS on user1 which has 0)
-        vm.expectRevert();
-        admiralsQuarters.moveFromCompoundToAdmiralsQuarters(
-            CUSDC_ADDRESS,
-            1000
+        calls[0] = abi.encodeCall(
+            admiralsQuarters.moveFromCompoundToAdmiralsQuarters,
+            (CUSDC_ADDRESS, 1000)
         );
+        vm.expectRevert();
+        admiralsQuarters.multicall(calls);
 
         vm.stopPrank();
     }


### PR DESCRIPTION
## Description
This PR resolves an issue in `AdmiralsQuarters` and `AdmiralsQuartersWhitelist` where the `moveFromERC4626ToAdmiralsQuarters` method failed to validate the `vault` token address. The lack of validation allowed potential execution flows with `address(0)` or invalid fleet commander vaults.

## Changes
- Added `_validateToken(IERC20(vault))` to `AdmiralsQuarters.moveFromERC4626ToAdmiralsQuarters`.
- Added `_validateToken(IERC20(vault))` to `AdmiralsQuartersWhitelist.moveFromERC4626ToAdmiralsQuarters`.
- Refactored `test_ImportReverts` across test suites to properly trigger internal modifiers using `multicall()`, ensuring precise revert testing.
- Updated relevant test suites to explicitly expect the `InvalidToken()` error instead of generic reverts.

## Benefits
1. **Enhanced Security**: Ensures no interaction can occur with `address(0)` or unauthorized vault addresses during the ERC4626 import process.
2. **Consistency**: Aligns the security logic of `moveFromERC4626ToAdmiralsQuarters` with existing validation patterns in the codebase.
3. **Robust Testing**: Re-structuring the tests to correctly use `multicall()` ensures modifiers like `onlyMulticall` are met so that the underlying logic validation is accurately tested.

## Testing
- Modified `test_ImportReverts` in `AdmiralsQuartersWhitelist.t.sol` and `AdmiralsQuarters.import.t.sol` to expect the exact `InvalidToken()` signature.
- Ran the full `AdmiralsQuarters` test suite. All tests pass successfully.

## Additional Notes
During testing, it was discovered that `test_ImportReverts` tests were previously passing because they were reverting with `NotMulticall()` instead of properly testing the internal logic. This was fixed by refactoring the tests to properly wrap operations in `multicall()`.

Please review and provide any feedback or suggestions for improvement.
