### PR TITLE
fix(core-contracts): prevent double-counting tips in FleetCommanderWhitelist

### DIFF
--- a/packages/core-contracts/src/contracts/FleetCommanderWhitelist.sol
+++ b/packages/core-contracts/src/contracts/FleetCommanderWhitelist.sol
@@ -310,7 +310,7 @@ contract FleetCommanderWhitelist is
 
     /// @inheritdoc IFleetCommanderWhitelist
     function tip() public onlyKeeper whenNotPaused returns (uint256) {
-        return _accrueTip(tipJar(), totalSupply());
+        return _accrueTip(tipJar(), super.totalSupply());
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -478,7 +478,7 @@ contract FleetCommanderWhitelist is
     function setPerformanceFeeRate(
         Percentage newRate
     ) external onlyGovernor whenNotPaused {
-        _setPerformanceFeeRate(newRate, tipJar(), totalSupply());
+        _setPerformanceFeeRate(newRate, tipJar(), super.totalSupply());
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/packages/core-contracts/test/fleets/FleetCommanderWhitelist.t.sol
+++ b/packages/core-contracts/test/fleets/FleetCommanderWhitelist.t.sol
@@ -689,4 +689,83 @@ contract FleetCommanderWhitelistTest is
         whitelistFleet.redeemFromArks(1, mockUser2, operator);
         vm.stopPrank();
     }
+
+    /**
+     * @notice Tests that tip() manual call correctly accrues tip using super.totalSupply()
+     * avoiding recursive double-counting of the previewed tip.
+     */
+    function test_Tip_ManualCall_UsesSuperTotalSupply() public {
+        vm.prank(governor);
+        whitelistFleet.setTipRate(PercentageUtils.fromIntegerPercentage(5));
+
+        uint256 initialSupply = whitelistFleet.totalSupply(); // same as super.totalSupply() right after setTipRate
+
+        vm.warp(block.timestamp + 365 days);
+
+        uint256 expectedTip = whitelistFleet.previewTip(
+            whitelistFleet.tipJar(),
+            initialSupply
+        );
+        uint256 initialTipJarBalance = whitelistFleet.balanceOf(
+            whitelistFleet.tipJar()
+        );
+
+        vm.startPrank(keeper);
+        whitelistFleet.tip();
+        vm.stopPrank();
+
+        uint256 finalTipJarBalance = whitelistFleet.balanceOf(
+            whitelistFleet.tipJar()
+        );
+
+        assertEq(
+            finalTipJarBalance - initialTipJarBalance,
+            expectedTip,
+            "Manual tip accrual should match expected tip calculated on base supply"
+        );
+    }
+
+    /**
+     * @notice Tests that setPerformanceFeeRate correctly accrues the tip using super.totalSupply()
+     * before changing the rate.
+     */
+    function test_SetPerformanceFeeRate_UsesSuperTotalSupply() public {
+        vm.prank(governor);
+        whitelistFleet.setFeeType(IFlexibleTipper.FeeType.PERFORMANCE);
+        
+        vm.prank(governor);
+        whitelistFleet.setPerformanceFeeRate(PercentageUtils.fromIntegerPercentage(5));
+
+        uint256 initialSupply = whitelistFleet.totalSupply();
+
+        // Simulate some time and yield
+        vm.warp(block.timestamp + 365 days);
+        
+        // mock token yield into the buffer ark to generate performance fee
+        mockToken.mint(address(whitelistFleet.bufferArk()), 10 * 10 ** 6);
+
+        uint256 expectedTip = whitelistFleet.previewTip(
+            whitelistFleet.tipJar(),
+            initialSupply
+        );
+        
+        uint256 initialTipJarBalance = whitelistFleet.balanceOf(
+            whitelistFleet.tipJar()
+        );
+
+        vm.startPrank(governor);
+        // Change fee rate to trigger accrual
+        whitelistFleet.setPerformanceFeeRate(PercentageUtils.fromIntegerPercentage(10));
+        vm.stopPrank();
+
+        uint256 finalTipJarBalance = whitelistFleet.balanceOf(
+            whitelistFleet.tipJar()
+        );
+
+        assertEq(
+            finalTipJarBalance - initialTipJarBalance,
+            expectedTip,
+            "Fee rate change tip accrual should match expected tip calculated on base supply"
+        );
+    }
 }


### PR DESCRIPTION
## Description
This PR resolves an issue in `FleetCommanderWhitelist` where accrued tips were being double-counted when the `tip()` and `setPerformanceFeeRate()` functions were called. It replaces the use of `totalSupply()` with `super.totalSupply()` to ensure accurate fee calculations without incorporating unaccrued tips recursively.

## Changes
- Changed `totalSupply()` to `super.totalSupply()` inside the manual `tip()` function.
- Changed `totalSupply()` to `super.totalSupply()` inside the `setPerformanceFeeRate()` function.
- Added test `test_Tip_ManualCall_UsesSuperTotalSupply` to verify correct tip accrual.
- Added test `test_SetPerformanceFeeRate_UsesSuperTotalSupply` to verify proper fee evaluation upon fee rate modification.

## Benefits
1. **Accurate Fee Accrual:** Prevents the tip calculations from recursively applying fees onto themselves, avoiding over-minting of fee shares.
2. **Improved Coverage:** Added comprehensive tests mapping exact tip calculations for manual calls.
3. **State Integrity:** Ensures `FleetCommanderWhitelist` base supply strictly dictates tip values without bleeding unaccrued tips into the calculation logic.

## Testing
- Verified locally using Forge test suite: `forge test --match-contract FleetCommanderWhitelistTest`
- Added 2 new targeted unit tests which fail under the old code and pass strictly with the fix.

## Additional Notes
This bug specifically affected the calculation executed by `_accrueTip` since `FleetCommanderWhitelist` overrides `totalSupply()` to dynamically append the `previewTip()`. Utilizing `super.totalSupply()` pulls directly from the underlying ERC20 tracking to resolve the cyclic dependency.

