### PR TITLE
fix(core-contracts): prevent sweep when WisdomTreeArk is frozen

### DIFF
--- a/packages/core-contracts/src/contracts/arks/WisdomTreeArk.sol
+++ b/packages/core-contracts/src/contracts/arks/WisdomTreeArk.sol
@@ -364,6 +364,7 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
         public
         override
         onlyKeeper
+        onlyNotFrozen
         nonReentrant
         returns (address[] memory sweptTokens, uint256[] memory sweptAmounts)
     {

--- a/packages/core-contracts/test/arks/WisdomTreeArk.t.sol
+++ b/packages/core-contracts/test/arks/WisdomTreeArk.t.sol
@@ -342,6 +342,16 @@ contract WisdomTreeArkTest is Test, IArkEvents, ArkTestBaseWhitelist {
         vm.stopPrank();
     }
 
+    function test_RevertSweepWhenFrozen() public {
+        vm.prank(keeper);
+        ark.setArkFrozen(true, type(uint256).max);
+
+        vm.startPrank(keeper);
+        vm.expectRevert(WisdomTreeArk.ArkIsFrozen.selector);
+        ark.sweep();
+        vm.stopPrank();
+    }
+
     function test_TotalAssetsIsCachedWhenFrozen_MaxUint256() public {
         uint256 amount = 60000 * 1e6; // 1 share worth
         deal(USDC_ADDRESS, commander, amount);


### PR DESCRIPTION
## Description
This PR updates `WisdomTreeArk` to enforce the `onlyNotFrozen` modifier on the `sweep()` function. This prevents keepers or the system from successfully sweeping withdrawal funds while the Ark is in a frozen state, closing a potential vulnerability where operations could progress during an emergency freeze.

## Changes
- Added the `onlyNotFrozen` modifier to `WisdomTreeArk::sweep()`.
- Added the `test_RevertSweepWhenFrozen` unit test to `WisdomTreeArk.t.sol` to explicitly verify that the sweep function reverts with `WisdomTreeArk.ArkIsFrozen` when the ark is frozen.

## Benefits
1. **Security Enhancement:** Guarantees that no funds can be swept out of the Ark during an emergency freeze, fully respecting the protocol's pause mechanism.
2. **State Consistency:** Ensures that the pending withdrawal state remains locked and cannot be resolved while frozen.
3. **Improved Test Coverage:** Ensures this security constraint is actively enforced by the test suite to prevent future regressions.

## Testing
- Verified locally using Forge test suite: `forge test --match-contract WisdomTreeArk`
- The new test `test_RevertSweepWhenFrozen` successfully catches and prevents the sweep operation when the Ark is frozen. All 40 existing tests pass.

## Additional Notes
Other test paths within the suite were unimpacted as they accurately model valid state flows without attempting to execute `sweep()` while the Ark is frozen.
