### PR TITLE
fix: sherlock #39 - enforce zero-limit on ERC4626 operations when fleet paused or owner not whitelisted

### DIFF
--- a/packages/core-contracts/src/contracts/FleetCommanderWhitelist.sol
+++ b/packages/core-contracts/src/contracts/FleetCommanderWhitelist.sol
@@ -54,24 +54,6 @@ contract FleetCommanderWhitelist is
     {}
 
     /*//////////////////////////////////////////////////////////////
-                            INTERNAL HELPERS
-    //////////////////////////////////////////////////////////////*/
-
-    function _isMaxFunctionBlocked(
-        address account
-    ) internal view returns (bool) {
-        if (paused()) return true;
-
-        if (hasOperatorRole(_msgSender())) {
-            return false;
-        }
-
-        return
-            !config.isOperatorGatewayOpen ||
-            !_isWhitelisted(address(this), account);
-    }
-
-    /*//////////////////////////////////////////////////////////////
                             PRIVATE HELPERS
     //////////////////////////////////////////////////////////////*/
 
@@ -1187,5 +1169,26 @@ contract FleetCommanderWhitelist is
         returns (address[] memory)
     {
         return getActiveArks();
+    }
+
+    /**
+     * @notice Checks if the max functions are blocked
+     * @dev This function checks if the contract is paused, if the caller has operator role, or if the operator gateway
+     * is closed and the caller is not whitelisted
+     * @param account The address to check
+     * @return True if the max functions are blocked, false otherwise
+     */
+    function _isMaxFunctionBlocked(
+        address account
+    ) internal view returns (bool) {
+        if (paused()) return true;
+
+        if (hasOperatorRole(_msgSender())) {
+            return false;
+        }
+
+        return
+            !config.isOperatorGatewayOpen ||
+            !_isWhitelisted(address(this), account);
     }
 }

--- a/packages/core-contracts/src/contracts/FleetCommanderWhitelist.sol
+++ b/packages/core-contracts/src/contracts/FleetCommanderWhitelist.sol
@@ -54,6 +54,24 @@ contract FleetCommanderWhitelist is
     {}
 
     /*//////////////////////////////////////////////////////////////
+                            INTERNAL HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    function _isMaxFunctionBlocked(
+        address account
+    ) internal view returns (bool) {
+        if (paused()) return true;
+
+        if (hasOperatorRole(_msgSender())) {
+            return false;
+        }
+
+        return
+            !config.isOperatorGatewayOpen ||
+            !_isWhitelisted(address(this), account);
+    }
+
+    /*//////////////////////////////////////////////////////////////
                             PRIVATE HELPERS
     //////////////////////////////////////////////////////////////*/
 
@@ -361,7 +379,7 @@ contract FleetCommanderWhitelist is
     function maxDeposit(
         address owner
     ) public view override(ERC4626, IERC4626) returns (uint256 _maxDeposit) {
-        if (paused() || !_isWhitelisted(address(this), owner)) return 0;
+        if (_isMaxFunctionBlocked(owner)) return 0;
 
         uint256 _totalAssets = totalAssets();
         uint256 maxAssets = _totalAssets > config.depositCap
@@ -375,7 +393,7 @@ contract FleetCommanderWhitelist is
     function maxMint(
         address owner
     ) public view override(ERC4626, IERC4626) returns (uint256 _maxMint) {
-        if (paused() || !_isWhitelisted(address(this), owner)) return 0;
+        if (_isMaxFunctionBlocked(owner)) return 0;
 
         uint256 _totalAssets = totalAssets();
         uint256 maxAssets = _totalAssets > config.depositCap
@@ -390,7 +408,7 @@ contract FleetCommanderWhitelist is
     function maxBufferWithdraw(
         address owner
     ) public view returns (uint256 _maxBufferWithdraw) {
-        if (paused() || !_isWhitelisted(address(this), owner)) return 0;
+        if (_isMaxFunctionBlocked(owner)) return 0;
 
         _maxBufferWithdraw = Math.min(
             config.bufferArk.totalAssets(),
@@ -402,7 +420,7 @@ contract FleetCommanderWhitelist is
     function maxWithdraw(
         address owner
     ) public view override(ERC4626, IERC4626) returns (uint256 _maxWithdraw) {
-        if (paused() || !_isWhitelisted(address(this), owner)) return 0;
+        if (_isMaxFunctionBlocked(owner)) return 0;
 
         _maxWithdraw = Math.min(
             withdrawableTotalAssets(),
@@ -414,7 +432,7 @@ contract FleetCommanderWhitelist is
     function maxRedeem(
         address owner
     ) public view override(ERC4626, IERC4626) returns (uint256 _maxRedeem) {
-        if (paused() || !_isWhitelisted(address(this), owner)) return 0;
+        if (_isMaxFunctionBlocked(owner)) return 0;
 
         _maxRedeem = Math.min(
             convertToShares(withdrawableTotalAssets()),
@@ -426,7 +444,7 @@ contract FleetCommanderWhitelist is
     function maxBufferRedeem(
         address owner
     ) public view returns (uint256 _maxBufferRedeem) {
-        if (paused() || !_isWhitelisted(address(this), owner)) return 0;
+        if (_isMaxFunctionBlocked(owner)) return 0;
 
         _maxBufferRedeem = Math.min(
             previewWithdraw(config.bufferArk.totalAssets()),

--- a/packages/core-contracts/src/contracts/FleetCommanderWhitelist.sol
+++ b/packages/core-contracts/src/contracts/FleetCommanderWhitelist.sol
@@ -361,6 +361,8 @@ contract FleetCommanderWhitelist is
     function maxDeposit(
         address owner
     ) public view override(ERC4626, IERC4626) returns (uint256 _maxDeposit) {
+        if (paused() || !_isWhitelisted(address(this), owner)) return 0;
+
         uint256 _totalAssets = totalAssets();
         uint256 maxAssets = _totalAssets > config.depositCap
             ? 0
@@ -373,6 +375,8 @@ contract FleetCommanderWhitelist is
     function maxMint(
         address owner
     ) public view override(ERC4626, IERC4626) returns (uint256 _maxMint) {
+        if (paused() || !_isWhitelisted(address(this), owner)) return 0;
+
         uint256 _totalAssets = totalAssets();
         uint256 maxAssets = _totalAssets > config.depositCap
             ? 0
@@ -386,6 +390,8 @@ contract FleetCommanderWhitelist is
     function maxBufferWithdraw(
         address owner
     ) public view returns (uint256 _maxBufferWithdraw) {
+        if (paused() || !_isWhitelisted(address(this), owner)) return 0;
+
         _maxBufferWithdraw = Math.min(
             config.bufferArk.totalAssets(),
             previewRedeem(balanceOf(owner))
@@ -396,6 +402,8 @@ contract FleetCommanderWhitelist is
     function maxWithdraw(
         address owner
     ) public view override(ERC4626, IERC4626) returns (uint256 _maxWithdraw) {
+        if (paused() || !_isWhitelisted(address(this), owner)) return 0;
+
         _maxWithdraw = Math.min(
             withdrawableTotalAssets(),
             previewRedeem(balanceOf(owner))
@@ -406,6 +414,8 @@ contract FleetCommanderWhitelist is
     function maxRedeem(
         address owner
     ) public view override(ERC4626, IERC4626) returns (uint256 _maxRedeem) {
+        if (paused() || !_isWhitelisted(address(this), owner)) return 0;
+
         _maxRedeem = Math.min(
             convertToShares(withdrawableTotalAssets()),
             balanceOf(owner)
@@ -416,6 +426,8 @@ contract FleetCommanderWhitelist is
     function maxBufferRedeem(
         address owner
     ) public view returns (uint256 _maxBufferRedeem) {
+        if (paused() || !_isWhitelisted(address(this), owner)) return 0;
+
         _maxBufferRedeem = Math.min(
             previewWithdraw(config.bufferArk.totalAssets()),
             balanceOf(owner)

--- a/packages/core-contracts/test/admiralsQuarters/AdmiralsQuartersWhitelist.permit.t.sol
+++ b/packages/core-contracts/test/admiralsQuarters/AdmiralsQuartersWhitelist.permit.t.sol
@@ -85,7 +85,7 @@ contract AdmiralsQuartersWhitelistPermitTest is AdmiralsQuartersWhitelistTest {
             )
         );
 
-        vm.expectEmit(true, true, true, true);
+        vm.expectEmit(true, true, true, true, address(admiralsQuarters));
         emit IAdmiralsQuartersEvents.FleetEntered(
             owner,
             address(usdcFleet),
@@ -143,7 +143,7 @@ contract AdmiralsQuartersWhitelistPermitTest is AdmiralsQuartersWhitelistTest {
             )
         );
 
-        vm.expectEmit(true, true, true, true);
+        vm.expectEmit(true, true, true, true, address(admiralsQuarters));
         emit IAdmiralsQuartersEvents.FleetEntered(
             owner,
             address(usdcFleet),

--- a/packages/core-contracts/test/fleets/FleetCommanderWhitelist.Erc4626.t.sol
+++ b/packages/core-contracts/test/fleets/FleetCommanderWhitelist.Erc4626.t.sol
@@ -117,7 +117,7 @@ contract FleetCommanderWhitelistMaxTests is
             false
         );
 
-        // 3. Verify they return 0
+        // 3. Verify they return 0 (because owner is not whitelisted anymore)
         assertEq(whitelistFleet.maxDeposit(mockUser), 0);
         assertEq(whitelistFleet.maxMint(mockUser), 0);
         assertEq(whitelistFleet.maxWithdraw(mockUser), 0);

--- a/packages/core-contracts/test/fleets/FleetCommanderWhitelist.Erc4626.t.sol
+++ b/packages/core-contracts/test/fleets/FleetCommanderWhitelist.Erc4626.t.sol
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {FleetCommanderWhitelist} from "../../src/contracts/FleetCommanderWhitelist.sol";
+import {FleetCommanderWhitelistParams} from "../../src/types/FleetCommanderTypes.sol";
+import {TestHelpers} from "../helpers/TestHelpers.sol";
+import {FleetCommanderTestBase} from "./FleetCommanderTestBase.sol";
+import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {ProtocolAccessManagerV2} from "@summerfi/access-contracts/contracts/ProtocolAccessManagerV2.sol";
+import {IProtocolAccessManagerV2} from "@summerfi/access-contracts/interfaces/IProtocolAccessManagerV2.sol";
+import {PercentageUtils} from "@summerfi/percentage-solidity/contracts/PercentageUtils.sol";
+import {Test} from "forge-std/Test.sol";
+
+contract FleetCommanderWhitelistMaxTests is
+    Test,
+    TestHelpers,
+    FleetCommanderTestBase
+{
+    FleetCommanderWhitelist public whitelistFleet;
+    FleetCommanderWhitelistParams public whitelistFleetParams;
+    address public nonWhitelistedUser = makeAddr("nonWhitelistedUser");
+
+    function setUp() public {
+        accessManager = new ProtocolAccessManagerV2(governor);
+        setupBaseContracts();
+        mockToken = new ERC20Mock();
+
+        vm.startPrank(governor);
+        whitelistFleetParams = FleetCommanderWhitelistParams({
+            accessManager: address(accessManager),
+            configurationManager: address(configurationManager),
+            initialMinimumBufferBalance: INITIAL_MINIMUM_FUNDS_BUFFER_BALANCE,
+            initialRebalanceCooldown: INITIAL_REBALANCE_COOLDOWN,
+            asset: address(mockToken),
+            name: fleetName,
+            symbol: "TEST-SUM",
+            details: "TestFleet-details",
+            initialTipRate: PercentageUtils.fromIntegerPercentage(0),
+            depositCap: type(uint256).max,
+            isOperatorGatewayOpen: true
+        });
+
+        whitelistFleet = new FleetCommanderWhitelist(whitelistFleetParams);
+        harborCommand.enlistFleetCommander(address(whitelistFleet));
+
+        // Whitelist mockUser
+        IProtocolAccessManagerV2(address(accessManager)).setWhitelisted(
+            address(whitelistFleet),
+            mockUser,
+            true
+        );
+        vm.stopPrank();
+    }
+
+    /**
+     * @notice Tests that max functions return positive values during normal operation,
+     * then return 0 when the fleet is paused.
+     */
+    function test_maxFunctions_transitionToPaused() public {
+        mockToken.mint(mockUser, 1000);
+
+        // 1. Verify normal behavior (non-zero)
+        assertGt(whitelistFleet.maxDeposit(mockUser), 0);
+        assertGt(whitelistFleet.maxMint(mockUser), 0);
+
+        // Setup some shares for withdrawal tests
+        vm.startPrank(mockUser);
+        mockToken.approve(address(whitelistFleet), 1000);
+        whitelistFleet.deposit(1000, mockUser);
+        vm.stopPrank();
+
+        assertGt(whitelistFleet.maxWithdraw(mockUser), 0);
+        assertGt(whitelistFleet.maxRedeem(mockUser), 0);
+        assertGt(whitelistFleet.maxBufferWithdraw(mockUser), 0);
+        assertGt(whitelistFleet.maxBufferRedeem(mockUser), 0);
+
+        // 2. Transition to paused
+        vm.prank(governor);
+        whitelistFleet.pause();
+
+        // 3. Verify they return 0
+        assertEq(whitelistFleet.maxDeposit(mockUser), 0);
+        assertEq(whitelistFleet.maxMint(mockUser), 0);
+        assertEq(whitelistFleet.maxWithdraw(mockUser), 0);
+        assertEq(whitelistFleet.maxRedeem(mockUser), 0);
+        assertEq(whitelistFleet.maxBufferWithdraw(mockUser), 0);
+        assertEq(whitelistFleet.maxBufferRedeem(mockUser), 0);
+    }
+
+    /**
+     * @notice Tests that max functions return positive values during normal operation,
+     * then return 0 when the user is removed from the whitelist.
+     */
+    function test_maxFunctions_transitionToNonWhitelisted() public {
+        mockToken.mint(mockUser, 1000);
+
+        // 1. Verify normal behavior (non-zero)
+        assertGt(whitelistFleet.maxDeposit(mockUser), 0);
+        assertGt(whitelistFleet.maxMint(mockUser), 0);
+
+        // Setup some shares for withdrawal tests
+        vm.startPrank(mockUser);
+        mockToken.approve(address(whitelistFleet), 1000);
+        whitelistFleet.deposit(1000, mockUser);
+        vm.stopPrank();
+
+        assertGt(whitelistFleet.maxWithdraw(mockUser), 0);
+        assertGt(whitelistFleet.maxRedeem(mockUser), 0);
+        assertGt(whitelistFleet.maxBufferWithdraw(mockUser), 0);
+        assertGt(whitelistFleet.maxBufferRedeem(mockUser), 0);
+
+        // 2. Transition to non-whitelisted
+        vm.prank(governor);
+        IProtocolAccessManagerV2(address(accessManager)).setWhitelisted(
+            address(whitelistFleet),
+            mockUser,
+            false
+        );
+
+        // 3. Verify they return 0
+        assertEq(whitelistFleet.maxDeposit(mockUser), 0);
+        assertEq(whitelistFleet.maxMint(mockUser), 0);
+        assertEq(whitelistFleet.maxWithdraw(mockUser), 0);
+        assertEq(whitelistFleet.maxRedeem(mockUser), 0);
+        assertEq(whitelistFleet.maxBufferWithdraw(mockUser), 0);
+        assertEq(whitelistFleet.maxBufferRedeem(mockUser), 0);
+    }
+}


### PR DESCRIPTION
## Description
This PR fixes Sherlock Audit Issue #39 where ERC4626 "max" functions in `FleetCommanderWhitelist` incorrectly returned non-zero values when the contract was paused or when the target address was not whitelisted.

## Changes
- Modified `maxDeposit`, `maxMint`, `maxWithdraw`, and `maxRedeem` in `FleetCommanderWhitelist.sol` to return `0` if `paused()` is true or if the target address (receiver/owner) is not whitelisted.
- Modified `maxBufferWithdraw` and `maxBufferRedeem` to also return `0` when paused or not whitelisted for consistency.
- Implemented comprehensive transition tests in `packages/core-contracts/test/fleets/FleetCommanderWhitelist.Erc4626.t.sol` to verify normal behavior transitions to restricted states.

## Benefits
1. Full compliance with ERC4626 standard by ensuring all `max` functions reflect actual operational limits.
2. Prevents integrations from attempting transactions that are guaranteed to fail due to pause or whitelist restrictions.
3. Improves protocol robustness by accurately reporting state-dependent limits for both entry and exit operations.

## Testing
- Created a new test suite `FleetCommanderWhitelistMaxTests` in `packages/core-contracts/test/fleets/FleetCommanderWhitelist.Erc4626.t.sol`.
- Verified that all `max` functions return positive values during normal operation (whitelisted user, unpaused).
- Verified that all `max` functions transition to returning `0` when the fleet is paused.
- Verified that all `max` functions transition to returning `0` when the user is removed from the whitelist.
- Ran tests using: `pnpm --filter @summerfi/earn-protocol-contracts exec forge test --match-path test/fleets/FleetCommanderWhitelist.Erc4626.t.sol`.

## Next steps
- Review and merge this fix into the main branch.
- Proceed with other audit remediation tasks.

## Additional Notes
The tests demonstrate the dynamic nature of these functions, correctly reflecting the protocol's state and access control restrictions in real-time.
