### PR TITLE
fix(core-contracts): prevent concurrent withdrawal requests in WisdomTreeArk

### DIFF
--- a/packages/core-contracts/src/contracts/arks/WisdomTreeArk.sol
+++ b/packages/core-contracts/src/contracts/arks/WisdomTreeArk.sol
@@ -84,6 +84,7 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
     error StaleOraclePrice();
     error InsufficientPendingDeposit();
     error PendingDepositActive();
+    error PendingWithdrawalActive();
     error ArkIsFrozen();
     error InvalidDepositSlippage(
         Percentage newSlippage,
@@ -322,6 +323,7 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
         uint256 amount
     ) external override onlyKeeper onlyNotFrozen {
         // Prevent concurrent deposit/withdrawal cycles
+        if (pendingWithdrawalShares > 0) revert PendingWithdrawalActive();
         if (pendingDepositAssets > 0) revert PendingDepositActive();
 
         uint256 sharesToRedeem = _assetsToShares(amount);

--- a/packages/core-contracts/test/arks/WisdomTreeArk.t.sol
+++ b/packages/core-contracts/test/arks/WisdomTreeArk.t.sol
@@ -488,6 +488,30 @@ contract WisdomTreeArkTest is Test, IArkEvents, ArkTestBaseWhitelist {
         vm.stopPrank();
     }
 
+    function test_RequestWithdrawal_RevertsIfPendingWithdrawal() public {
+        // 1. Setup fully cleared deposit
+        uint256 amount = 60000 * 1e6; // 1 share worth
+        deal(USDC_ADDRESS, commander, amount);
+        vm.startPrank(commander);
+        usdc.forceApprove(address(ark), amount);
+        ark.board(amount, bytes(""));
+        vm.stopPrank();
+
+        uint256 sharesMinted = 1e18;
+        wtToken.mint(address(ark), sharesMinted);
+
+        vm.startPrank(keeper);
+        ark.clearPendingDeposit();
+        
+        // 2. Request first withdrawal successfully
+        ark.requestWithdrawal(amount);
+        
+        // 3. Try to request another withdrawal while one is already pending
+        vm.expectRevert(WisdomTreeArk.PendingWithdrawalActive.selector);
+        ark.requestWithdrawal(amount);
+        vm.stopPrank();
+    }
+
     function test_RequestWithdrawal_And_Sweep() public {
         // 1. Setup fully cleared deposit
         uint256 amount = 60000 * 1e6; // 1 share worth


### PR DESCRIPTION
## Description
This PR updates `WisdomTreeArk.sol` to prevent concurrent withdrawal requests. A check has been added to `requestWithdrawal` to revert with `PendingWithdrawalActive()` if `pendingWithdrawalShares > 0`.

## Changes
- Updated `WisdomTreeArk::requestWithdrawal` to ensure that a withdrawal can only be requested if there is no pending withdrawal active.
- Added `test_RequestWithdrawal_RevertsIfPendingWithdrawal` to `WisdomTreeArk.t.sol` to explicitly verify this behavior and ensure the contract reverts when a second withdrawal is requested while the first one is still pending.

## Benefits
1. **Enhanced Security**: Prevents overlapping withdrawal flows that could lead to inconsistent share accounting or failed redemptions off-chain.
2. **Robustness**: Strictly enforces the one-at-a-time deposit/withdrawal lifecycle requirement in the WisdomTree integration.

## Testing
- Successfully ran the updated `WisdomTreeArk.t.sol` test suite verifying that `PendingWithdrawalActive()` is correctly triggered under the edge case.
- All 521 protocol tests passed, confirming no regressions.

## Additional Notes
- None.
