### PR TITLE
fix: sherlock #52 - transient flag for rounds vault exchange

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
       "axios@>=0.8.1 <0.28.0": ">=0.28.0",
       "cookie@<0.7.0": ">=0.7.0",
       "parse-duration@<2.1.3": ">=2.1.3",
-      "ejs@<3.1.10": ">=3.1.10"
+      "ejs@<3.1.10": ">=3.1.10",
+      "@solidity-parser/parser": "0.20.2"
     }
   },
   "name": "summerfi-monorepo",

--- a/packages/core-contracts/src/contracts/rounds-vault/RoundsVaultBase.sol
+++ b/packages/core-contracts/src/contracts/rounds-vault/RoundsVaultBase.sol
@@ -72,7 +72,7 @@ abstract contract RoundsVaultBase is
     BaseVaultType public immutable VAULT_TYPE;
 
     /// @dev Transient storage to track if the user is redeeming receipts for shares for themselve
-    bool isSelfRedeeming;
+    bool transient isSelfRedeeming;
 
     /**
      * CONSTRUCTOR

--- a/packages/core-contracts/src/contracts/rounds-vault/RoundsVaultBase.sol
+++ b/packages/core-contracts/src/contracts/rounds-vault/RoundsVaultBase.sol
@@ -71,6 +71,9 @@ abstract contract RoundsVaultBase is
     /// Output: Underlying = proxiedVault (the shares), ExchangeAsset = proxiedVault.asset()
     BaseVaultType public immutable VAULT_TYPE;
 
+    /// @dev Transient storage to track if the vault is redeeming
+    bool isRedeeming;
+
     /**
      * CONSTRUCTOR
      */
@@ -408,12 +411,15 @@ abstract contract RoundsVaultBase is
 
         if (from != address(0) && from != address(this)) {
             _revertIfNotWhitelisted(vault, from);
-            _validateAggregateAssets(
-                from,
-                isInputVault,
-                _minPositionSize,
-                vault
-            );
+
+            if (!isRedeeming) {
+                _validateAggregateAssets(
+                    from,
+                    isInputVault,
+                    _minPositionSize,
+                    vault
+                );
+            }
         }
     }
 
@@ -567,7 +573,9 @@ abstract contract RoundsVaultBase is
         //
         // Conclusion: we need to do the transfer after the burn so that any reentrancy would happen after the
         // shares are burned and after the assets are transfered, which is a valid state.
+        isRedeeming = true;
         _burn(owner, id, amount);
+        isRedeeming = false;
 
         exchangeAmount = _exchangeRateByRound[id].quote(amount);
 
@@ -620,7 +628,9 @@ abstract contract RoundsVaultBase is
         //
         // Conclusion: we need to do the transfer after the burn so that any reentrancy would happen after the
         // shares are burned and after the assets are transfered, which is a valid state.
+        isRedeeming = true;
         _burnBatch(owner, ids, amounts);
+        isRedeeming = false;
 
         for (uint256 i = 0; i < ids.length; i++) {
             exchangeAmount += _exchangeRateByRound[ids[i]].quote(amounts[i]);

--- a/packages/core-contracts/src/contracts/rounds-vault/RoundsVaultBase.sol
+++ b/packages/core-contracts/src/contracts/rounds-vault/RoundsVaultBase.sol
@@ -71,7 +71,7 @@ abstract contract RoundsVaultBase is
     /// Output: Underlying = proxiedVault (the shares), ExchangeAsset = proxiedVault.asset()
     BaseVaultType public immutable VAULT_TYPE;
 
-    /// @dev Transient storage to track if the vault is redeeming
+    /// @dev Transient storage to track if the user is redeeming receipts for shares for themselve
     bool isSelfRedeeming;
 
     /**

--- a/packages/core-contracts/src/contracts/rounds-vault/RoundsVaultBase.sol
+++ b/packages/core-contracts/src/contracts/rounds-vault/RoundsVaultBase.sol
@@ -72,7 +72,7 @@ abstract contract RoundsVaultBase is
     BaseVaultType public immutable VAULT_TYPE;
 
     /// @dev Transient storage to track if the vault is redeeming
-    bool isRedeeming;
+    bool isSelfRedeeming;
 
     /**
      * CONSTRUCTOR
@@ -412,7 +412,7 @@ abstract contract RoundsVaultBase is
         if (from != address(0) && from != address(this)) {
             _revertIfNotWhitelisted(vault, from);
 
-            if (!isRedeeming) {
+            if (!isSelfRedeeming) {
                 _validateAggregateAssets(
                     from,
                     isInputVault,
@@ -573,9 +573,9 @@ abstract contract RoundsVaultBase is
         //
         // Conclusion: we need to do the transfer after the burn so that any reentrancy would happen after the
         // shares are burned and after the assets are transfered, which is a valid state.
-        isRedeeming = true;
+        isSelfRedeeming = owner == receiver;
         _burn(owner, id, amount);
-        isRedeeming = false;
+        isSelfRedeeming = false;
 
         exchangeAmount = _exchangeRateByRound[id].quote(amount);
 
@@ -628,9 +628,9 @@ abstract contract RoundsVaultBase is
         //
         // Conclusion: we need to do the transfer after the burn so that any reentrancy would happen after the
         // shares are burned and after the assets are transfered, which is a valid state.
-        isRedeeming = true;
+        isSelfRedeeming = owner == receiver;
         _burnBatch(owner, ids, amounts);
-        isRedeeming = false;
+        isSelfRedeeming = false;
 
         for (uint256 i = 0; i < ids.length; i++) {
             exchangeAmount += _exchangeRateByRound[ids[i]].quote(amounts[i]);

--- a/packages/core-contracts/test/rounds-vault/RoundsVaultMinPosition.t.sol
+++ b/packages/core-contracts/test/rounds-vault/RoundsVaultMinPosition.t.sol
@@ -285,11 +285,8 @@ contract RoundsVaultMinPositionTest is
         inputVault.setRoundSettled(0); // Round 0 -> Settled
         vm.stopPrank();
 
-        // User now has 500e6 direct shares and 1000e6 receipts for round 0.
         // User redeems all their receipts.
         vm.startPrank(user);
-        // Before Issue 52 fix, this would revert because during `_burn(1000e6)`,
-        // the receipt balance drops to 0, leaving aggregate balance = 500e6 < MIN_POSITION
         inputVault.redeemExchangeAsset(0, 1000e6, user, user);
 
         // Ensure redemption was successful and user received the target shares
@@ -314,9 +311,9 @@ contract RoundsVaultMinPositionTest is
         vm.stopPrank();
 
         vm.startPrank(user);
-        // User attempts to redeem and send shares to someone else
-        // This will burn the 1000 receipts, leaving them with 500e6 direct shares
-        // Since 500e6 < 1000e6 (MIN_POSITION), it must revert!
+        // User attempts to redeem and send shares to another receiver
+        // This will burn 1000 receipts, leaving them with 500e6 direct shares
+        // Reverts because 500e6 < MIN_POSITION
         vm.expectRevert(
             abi.encodeWithSelector(
                 RoundsVaultPositionTooSmall.selector,
@@ -329,9 +326,7 @@ contract RoundsVaultMinPositionTest is
         vm.stopPrank();
     }
 
-    function test_MinPosition_RedeemExchangeAsset_LossRound_LocksFunds()
-        public
-    {
+    function test_MinPosition_RedeemExchangeAsset_LossRound_Succeeds() public {
         vm.startPrank(user);
         // User deposits exactly MIN_POSITION (1000e6)
         inputVault.deposit(1000e6, user);

--- a/packages/core-contracts/test/rounds-vault/RoundsVaultMinPosition.t.sol
+++ b/packages/core-contracts/test/rounds-vault/RoundsVaultMinPosition.t.sol
@@ -18,6 +18,7 @@ import {Test} from "forge-std/Test.sol";
 // Mock ERC4626
 contract MockERC4626 is ERC4626VaultMock {
     mapping(address => uint256) public shareBalances;
+
     constructor(address asset_) ERC4626VaultMock(asset_) {}
 
     function convertToShares(
@@ -294,6 +295,60 @@ contract RoundsVaultMinPositionTest is
         // Ensure redemption was successful and user received the target shares
         assertEq(targetVault.balanceOf(user), 1500e6);
         assertEq(inputVault.balanceOf(user, 0), 0);
+        vm.stopPrank();
+    }
+
+    function test_MinPosition_RedeemExchangeAsset_ReceiverDiffers_Reverts()
+        public
+    {
+        vm.startPrank(user);
+        // User deposits 1500e6 total (which is >= 1000 MIN_POSITION)
+        targetVault.deposit(500e6, user);
+        inputVault.deposit(1000e6, user);
+        vm.stopPrank();
+
+        // Admin advances and settles round 0
+        vm.startPrank(admin);
+        inputVault.nextRound(); // Round 0 -> InSettlement
+        inputVault.setRoundSettled(0); // Round 0 -> Settled
+        vm.stopPrank();
+
+        vm.startPrank(user);
+        // User attempts to redeem and send shares to someone else
+        // This will burn the 1000 receipts, leaving them with 500e6 direct shares
+        // Since 500e6 < 1000e6 (MIN_POSITION), it must revert!
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                RoundsVaultPositionTooSmall.selector,
+                user,
+                500e6,
+                MIN_POSITION
+            )
+        );
+        inputVault.redeemExchangeAsset(0, 1000e6, otherUser, user);
+        vm.stopPrank();
+    }
+
+    function test_MinPosition_RedeemExchangeAsset_LossRound_LocksFunds()
+        public
+    {
+        vm.startPrank(user);
+        // User deposits exactly MIN_POSITION (1000e6)
+        inputVault.deposit(1000e6, user);
+        vm.stopPrank();
+
+        vm.startPrank(user);
+        targetVault.deposit(900e6, user);
+        inputVault.deposit(600e6, user);
+        vm.stopPrank();
+
+        vm.startPrank(admin);
+        inputVault.nextRound(); // Round 0 -> InSettlement
+        inputVault.setRoundSettled(0); // Round 0 -> Settled
+        vm.stopPrank();
+
+        vm.startPrank(user);
+        inputVault.redeemExchangeAsset(0, 600e6, user, user);
         vm.stopPrank();
     }
 }

--- a/packages/core-contracts/test/rounds-vault/RoundsVaultMinPosition.t.sol
+++ b/packages/core-contracts/test/rounds-vault/RoundsVaultMinPosition.t.sol
@@ -115,6 +115,15 @@ contract RoundsVaultMinPositionTest is
         vm.prank(admin);
         outputVault.setMinPositionSize(MIN_POSITION);
 
+        // Grant keeper role to admin for testing round settlements
+        bytes32 specificKeeperRole = keccak256(
+            abi.encodePacked(
+                ContractSpecificRoles.KEEPER_ROLE,
+                address(inputVault)
+            )
+        );
+        accessManager.grantRole(specificKeeperRole, admin);
+
         usdc.mint(user, 10000e6);
         vm.prank(user);
         usdc.approve(address(inputVault), 10000e6);
@@ -257,6 +266,34 @@ contract RoundsVaultMinPositionTest is
         outputVault.deposit(1000e6, user);
         assertEq(outputVault.balanceOfAll(user), 1000e6);
         assertEq(targetVault.balanceOf(user), 0);
+        vm.stopPrank();
+    }
+
+    function test_MinPosition_RedeemExchangeAsset_Issue52_Succeeds() public {
+        vm.startPrank(user);
+        // User has direct target shares, but LESS than MIN_POSITION
+        targetVault.deposit(500e6, user);
+
+        // User deposits into inputVault to make aggregate balance >= MIN_POSITION (500 + 1000 = 1500 >= 1000)
+        inputVault.deposit(1000e6, user);
+        vm.stopPrank();
+
+        // Admin advances and settles round 0
+        vm.startPrank(admin);
+        inputVault.nextRound(); // Round 0 -> InSettlement
+        inputVault.setRoundSettled(0); // Round 0 -> Settled
+        vm.stopPrank();
+
+        // User now has 500e6 direct shares and 1000e6 receipts for round 0.
+        // User redeems all their receipts.
+        vm.startPrank(user);
+        // Before Issue 52 fix, this would revert because during `_burn(1000e6)`,
+        // the receipt balance drops to 0, leaving aggregate balance = 500e6 < MIN_POSITION
+        inputVault.redeemExchangeAsset(0, 1000e6, user, user);
+
+        // Ensure redemption was successful and user received the target shares
+        assertEq(targetVault.balanceOf(user), 1500e6);
+        assertEq(inputVault.balanceOf(user, 0), 0);
         vm.stopPrank();
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   cookie@<0.7.0: '>=0.7.0'
   parse-duration@<2.1.3: '>=2.1.3'
   ejs@<3.1.10: '>=3.1.10'
+  '@solidity-parser/parser': 0.20.2
 
 importers:
 
@@ -4380,11 +4381,8 @@ packages:
   '@solana/web3.js@1.98.4':
     resolution: {integrity: sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==}
 
-  '@solidity-parser/parser@0.16.2':
-    resolution: {integrity: sha512-PI9NfoA3P8XK2VBkK5oIfRgKDsicwDZfkVq9ZTBCQYGOP1N2owgY2dyLGyU5/J/hQs8KRk55kdmvTLjy3Mu3vg==}
-
-  '@solidity-parser/parser@0.17.0':
-    resolution: {integrity: sha512-Nko8R0/kUo391jsEHHxrGM07QFdnPGvlmox4rmH0kNiNAashItAilhy4Mv4pK5gQmW5f4sXAF58fwJbmlkGcVw==}
+  '@solidity-parser/parser@0.20.2':
+    resolution: {integrity: sha512-rbu0bzwNvMcwAjH86hiEAcOeRI2EeK8zCkHDrFykh/Al8mvJeFmjy3UrE7GYQjNwOgbGUUtCn5/k8CB8zIu7QA==}
 
   '@stargatefinance/stg-definitions-v2@2.0.5':
     resolution: {integrity: sha512-MDpKCm67CtSbQZI7NQZC2EUrl5pRA7w7lpaVnaiJd397rJUthlG4zPtep0WgOOyPvo0mO2vuLb44h+IVc/DybQ==}
@@ -5269,9 +5267,6 @@ packages:
   antlr4@4.13.2:
     resolution: {integrity: sha512-QiVbZhyy4xAZ17UPEuG3YTOt8ZaoeOR1CvEAqrEsDBsOqINslaB147i9xqljZqoyf5S+EUlGStaj+t22LT9MOg==}
     engines: {node: '>=16'}
-
-  antlr4ts@0.5.0-alpha.4:
-    resolution: {integrity: sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ==}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -15748,11 +15743,7 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@solidity-parser/parser@0.16.2':
-    dependencies:
-      antlr4ts: 0.5.0-alpha.4
-
-  '@solidity-parser/parser@0.17.0': {}
+  '@solidity-parser/parser@0.20.2': {}
 
   '@stargatefinance/stg-definitions-v2@2.0.5': {}
 
@@ -16981,8 +16972,6 @@ snapshots:
   ansis@3.17.0: {}
 
   antlr4@4.13.2: {}
-
-  antlr4ts@0.5.0-alpha.4: {}
 
   any-promise@1.3.0: {}
 
@@ -22771,21 +22760,21 @@ snapshots:
 
   prettier-plugin-solidity@1.3.1(prettier@3.0.0):
     dependencies:
-      '@solidity-parser/parser': 0.17.0
+      '@solidity-parser/parser': 0.20.2
       prettier: 3.0.0
       semver: 7.7.4
       solidity-comments-extractor: 0.0.8
 
   prettier-plugin-solidity@1.3.1(prettier@3.2.5):
     dependencies:
-      '@solidity-parser/parser': 0.17.0
+      '@solidity-parser/parser': 0.20.2
       prettier: 3.2.5
       semver: 7.7.4
       solidity-comments-extractor: 0.0.8
 
   prettier-plugin-solidity@1.3.1(prettier@3.4.2):
     dependencies:
-      '@solidity-parser/parser': 0.17.0
+      '@solidity-parser/parser': 0.20.2
       prettier: 3.4.2
       semver: 7.7.4
       solidity-comments-extractor: 0.0.8
@@ -23446,7 +23435,7 @@ snapshots:
 
   solhint@3.6.2(typescript@5.9.3):
     dependencies:
-      '@solidity-parser/parser': 0.16.2
+      '@solidity-parser/parser': 0.20.2
       ajv: 6.14.0
       antlr4: 4.13.2
       ast-parents: 0.0.1


### PR DESCRIPTION
## Description
Fixes Sherlock Issue #52 where the minimum position check reverts prematurely during redemption, and prevents a subsequent bypass where users could sidestep the minimum position invariant by redeeming exchange assets to a different receiver.

## Changes
- Replaced the transient storage logic with a clean state variable `bool isSelfRedeeming`..
- Wrapped `_burn` and `_burnBatch` inside `_redeemExchangeAsset` and `_redeemExchangeAssetBatch` with operations that set `isSelfRedeeming = owner == receiver` and clear it afterwards.
- Modified `_update()` to skip `_validateAggregateAssets` for the `from` address only if `isSelfRedeeming` is true.
- Removed the manual end-of-function validation checks, correctly relying on `_update` to handle enforcement for cross-account transfers.
- Added `test_MinPosition_RedeemExchangeAsset_Issue52_Succeeds` to verify that standard redemptions succeed.
- Added `test_MinPosition_RedeemExchangeAsset_ReceiverDiffers_Reverts` to verify that attempting to redeem to another receiver properly reverts if it leaves the owner's direct share balance below `minPositionSize`.
- Added `test_MinPosition_RedeemExchangeAsset_LossRound_Succeeds` to guarantee loss-making round exits are not trapped.

## Benefits
1. Prevents legitimate redemption transactions from reverting when the user's intermediate balance briefly drops below `minPositionSize` during the internal `_burn`.
2. Elegantly solves the cross-receiver bypass by keeping validation active when `receiver != owner`.
3. Ensures users are not permanently locked out of their funds if a round naturally settles at a loss, providing a robust solution that safely ignores the validation when users are simply swapping receipts for shares to themselves.

## Testing
- Successfully ran `forge test --match-contract RoundsVaultMinPositionTest` validating the fix, the receiver bypass edge case, and the loss-making round lock-in prevention.
- Full `core-contracts` integration test suite passes without any regressions.

Please review and provide any feedback or suggestions for improvement.
