### PR TITLE
fix: sherlock #51 - prevent setting performance fee rate to zero in FlexibleTipper

### DIFF
--- a/packages/core-contracts/src/contracts/FlexibleTipper.sol
+++ b/packages/core-contracts/src/contracts/FlexibleTipper.sol
@@ -41,6 +41,9 @@ abstract contract FlexibleTipper is IFlexibleTipper, Tipper {
                             CONSTANTS
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice A zero performance fee rate
+    Percentage immutable ZERO_PERFORMANCE_FEE_RATE = Percentage.wrap(0);
+
     /// @notice The maximum performance fee rate is 50%
     Percentage immutable MAX_PERFORMANCE_FEE_RATE = Percentage.wrap(50 * 1e18);
 
@@ -120,6 +123,9 @@ abstract contract FlexibleTipper is IFlexibleTipper, Tipper {
         address tipJar,
         uint256 _totalSupply
     ) internal {
+        if (newRate == ZERO_PERFORMANCE_FEE_RATE) {
+            revert PerformanceFeeRateCannotBeZero();
+        }
         if (newRate > MAX_PERFORMANCE_FEE_RATE) {
             revert PerformanceFeeRateTooHigh();
         }

--- a/packages/core-contracts/src/interfaces/IFlexibleTipper.sol
+++ b/packages/core-contracts/src/interfaces/IFlexibleTipper.sol
@@ -71,6 +71,11 @@ interface IFlexibleTipper is ITipper {
      */
     error PerformanceFeeRateTooHigh();
 
+    /**
+     * @notice Thrown when attempting to set the performance fee rate to zero
+     */
+    error PerformanceFeeRateCannotBeZero();
+
     /*//////////////////////////////////////////////////////////////
                             VIEW FUNCTIONS
     //////////////////////////////////////////////////////////////*/

--- a/packages/core-contracts/test/fleets/FlexibleTipper.t.sol
+++ b/packages/core-contracts/test/fleets/FlexibleTipper.t.sol
@@ -382,6 +382,13 @@ contract FlexibleTipperTest is Test, ITipperEvents {
         vault.setPerformanceFeeRate(PercentageUtils.fromIntegerPercentage(51));
     }
 
+    function test_SetPerformanceFeeRate_RevertIfZero() public {
+        vm.expectRevert(
+            abi.encodeWithSignature("PerformanceFeeRateCannotBeZero()")
+        );
+        vault.setPerformanceFeeRate(PercentageUtils.fromIntegerPercentage(0));
+    }
+
     function test_SetPerformanceFeeRate_Success() public {
         Percentage newRate = PercentageUtils.fromIntegerPercentage(15);
         vault.setPerformanceFeeRate(newRate);


### PR DESCRIPTION
## Description
Fixes Sherlock Issue #51 where setting the performance fee rate to `0` could be used to improperly pause the fee while freezing the High-Water Mark (HWM). When later unpaused, the fee would retroactively apply to gains accrued during the paused period.

## Changes
- Disallowed setting the performance fee to `0` by introducing a `PerformanceFeeRateCannotBeZero` error. 
- Modified `_setPerformanceFeeRate` in `FlexibleTipper.sol` to revert if the `newRate` is zero.
- Added `test_SetPerformanceFeeRate_RevertIfZero` in `FlexibleTipper.t.sol` to ensure this exact condition continues to revert as expected.

## Benefits
By enforcing a strict non-zero constraint on the `performanceFeeRate`, governance is now required to completely disable the performance fee by legitimately switching the `FeeType` using `setFeeType`. Switching `FeeType` enforces an automatic and correct HWM reset, solving the frozen-HWM vulnerability completely and gracefully.

## Testing
- Unit tested the revert correctly triggers with `test_SetPerformanceFeeRate_RevertIfZero`.
- Full integration test suite run successfully without any regressions.
