### PR TITLE
fix(arks): remove clearDeposit(amount) from WisdomTreeArk

### DIFF
--- a/packages/core-contracts/src/contracts/arks/WisdomTreeArk.sol
+++ b/packages/core-contracts/src/contracts/arks/WisdomTreeArk.sol
@@ -304,15 +304,6 @@ contract WisdomTreeArk is ArkWithWithdrawalRequest, ERC721Holder {
         _clearPendingDeposit(pendingDepositAssets);
     }
 
-    /**
-     * @notice Removes a fulfilled deposit amount from `pendingDepositAssets`.
-     * @dev Called by the keeper after WisdomTree issues shares to this contract to
-     *      clear a partial deposit.
-     */
-    function clearPendingDeposit(uint256 amount) external onlyKeeper {
-        _validateReceivedShares(amount);
-        _clearPendingDeposit(amount);
-    }
 
     /**
      * @inheritdoc IArkWithWithdrawalRequest

--- a/packages/core-contracts/src/contracts/rounds-vault/docs/wisdom_tree_ark_technical_reference.md
+++ b/packages/core-contracts/src/contracts/rounds-vault/docs/wisdom_tree_ark_technical_reference.md
@@ -35,9 +35,9 @@ stateDiagram-v2
 - **Double-Counting Protection**: If this is the start of a deposit queue, the Ark snapshots its current share balance into `cachedShareBalance`. While `pendingDepositAssets > 0`, the `totalAssets()` calculation uses `cachedShareBalance` instead of the live `balanceOf`. This prevents newly delivered shares from being counted twice (once as USDC and once as Shares) before the Keeper formally clears them.
 
 ### 2. Deposit Clearance
-- **Action**: `clearPendingDeposit(amount)`
+- **Action**: `clearPendingDeposit()`
 - **Requirement**: Shares must have arrived off-chain.
-- **Validation**: The Keeper verifies that the newly arrived shares meet the `depositSlippage` threshold relative to the current Oracle price. If validated, `pendingDepositAssets` is reduced, and the `cachedShareBalance` is updated.
+- **Validation**: The Keeper verifies that the newly arrived shares meet the `depositSlippage` threshold relative to the current Oracle price. If validated, `pendingDepositAssets` is cleared, and the `cachedShareBalance` is updated.
 
 ### 3. The Withdrawal Flow (Request)
 - **Action**: `requestWithdrawal(amount)`

--- a/packages/core-contracts/test/arks/WisdomTreeArk.t.sol
+++ b/packages/core-contracts/test/arks/WisdomTreeArk.t.sol
@@ -438,31 +438,6 @@ contract WisdomTreeArkTest is Test, IArkEvents, ArkTestBaseWhitelist {
         );
     }
 
-    function test_ClearPendingDepositAmount() public {
-        uint256 amount = 60000 * 1e6; // Exact price of 1 share
-        deal(USDC_ADDRESS, commander, amount);
-
-        vm.startPrank(commander);
-        usdc.forceApprove(address(ark), amount);
-        ark.board(amount, bytes(""));
-        vm.stopPrank();
-
-        assertEq(ark.pendingDepositAssets(), amount);
-
-        uint256 clearAmount = 10000 * 1e6;
-        uint256 equivalentShares = (clearAmount * 1e18) / amount;
-        deal(address(wtToken), address(ark), equivalentShares);
-
-        vm.startPrank(keeper);
-        ark.clearPendingDeposit(clearAmount);
-        vm.stopPrank();
-
-        assertEq(
-            ark.pendingDepositAssets(),
-            amount - clearAmount,
-            "Pending deposit should be partially cleared"
-        );
-    }
 
     function test_RevertBoardWhenPendingDepositNonMoneyMarket() public {
         uint256 amount = 1000 * 1e6;
@@ -860,46 +835,6 @@ contract WisdomTreeArkTest is Test, IArkEvents, ArkTestBaseWhitelist {
         );
     }
 
-    function test_ClearPendingDeposit_PartialClearance_SafeUpdate() public {
-        // Board 120k USDC (Expect 2 Shares)
-        uint256 amount = 120000 * 1e6;
-        deal(USDC_ADDRESS, commander, amount);
-
-        vm.startPrank(commander);
-        usdc.forceApprove(address(ark), amount);
-        ark.board(amount, bytes(""));
-        vm.stopPrank();
-
-        // Only 1 Share arrives off-chain initially
-        uint256 partialSharesMinted = 1e18;
-        wtToken.mint(address(ark), partialSharesMinted);
-
-        uint256 partialClearance = 60000 * 1e6; // Clear half the USDC
-
-        vm.startPrank(keeper);
-        ark.clearPendingDeposit(partialClearance); // Clear half
-        vm.stopPrank();
-
-        // Verify partial state
-        assertEq(
-            ark.pendingDepositAssets(),
-            60000 * 1e6,
-            "Half of the deposit should still be pending"
-        );
-        assertEq(
-            ark.cachedShareBalance(),
-            partialSharesMinted,
-            "Cache should safely track the partial delivery"
-        );
-
-        // Assert totalAssets is still completely stable
-        // 1 share in cache (60k) + 60k pending = 120k total
-        assertEq(
-            ark.totalAssets(),
-            amount,
-            "NAV should not shift during partial clearance"
-        );
-    }
 
     function test_EmergencyClearPendingDeposit_RescuesDeadlock() public {
         uint256 amount = 1200000 * 1e6; // $1.2M USDC -> 20 shares
@@ -928,11 +863,11 @@ contract WisdomTreeArkTest is Test, IArkEvents, ArkTestBaseWhitelist {
         vm.expectRevert(
             abi.encodeWithSelector(
                 WisdomTreeArk.SharesNotArrived.selector,
-                30e18, // Contract demands 30 shares based on today's cheap price
+                60e18, // Contract demands 60 shares based on today's cheap price for the full $1.2M deposit
                 partialSharesDelivered // Only 10 arrived
             )
         );
-        ark.clearPendingDeposit(clearanceAttempt);
+        ark.clearPendingDeposit();
         vm.stopPrank();
 
         // The Governor verifies off-chain that $600k was legitimately
@@ -1132,7 +1067,7 @@ contract WisdomTreeArkTest is Test, IArkEvents, ArkTestBaseWhitelist {
         vm.stopPrank();
 
         vm.startPrank(keeper);
-        ark.clearPendingDeposit(0);
+        ark.clearPendingDeposit();
         vm.stopPrank();
     }
 }


### PR DESCRIPTION
## Description
This PR removes the `clearPendingDeposit(amount)` overload from the `WisdomTreeArk` contract to prevent unintended or malicious partial clearances by the Keeper. The `clearPendingDeposit()` method will now exclusively clear the full `pendingDepositAssets` balance, while partial/custom clearances are strictly reserved for the Governor via `emergencyClearPendingDeposit(amount)`.

## Changes
- Removed the `clearPendingDeposit(uint256 amount)` method from `WisdomTreeArk.sol`.
- Removed `test_ClearPendingDepositAmount` and `test_ClearPendingDeposit_PartialClearance_SafeUpdate` unit tests that explicitly verified Keeper-driven partial clearance.
- Updated `test_EmergencyClearPendingDeposit_RescuesDeadlock` and `test_ZeroAmountTransfers` to rely on the parameterless `clearPendingDeposit()` instead.
- Updated the technical reference documentation in `wisdom_tree_ark_technical_reference.md` to remove references to the `amount` parameter for deposit clearance.

## Benefits
1. **Enhanced Security**: Reduces the risk of misaligned off-chain/on-chain states by enforcing full deposit clearances under normal Keeper operations.
2. **Simplified Interface**: Avoids potential ambiguity by consolidating deposit clearance flows.
3. **Restricted Privileges**: Ensures that complex edge cases requiring partial clearances can only be executed under the explicit authorization of the Governor.

## Testing
- The contract changes have been verified against the existing test suite (`forge test --match-contract WisdomTreeArk`).
- Existing tests that previously simulated Keeper partial clearance have been successfully migrated to use the Governor's emergency function or full clearance behavior.

## Additional Notes
N/A
