### PR TITLE
Revert "feat: restrict shake functions to keepers only (#790)"

### DIFF
--- a/packages/core-contracts/src/contracts/TipJar.sol
+++ b/packages/core-contracts/src/contracts/TipJar.sol
@@ -129,7 +129,7 @@ contract TipJar is
         _validateTipStreamAllocation(tipStream.allocation, currentAllocation);
 
         if (shakeAllFleetCommanders) {
-            _shakeAll();
+            shakeAll();
         }
         if (
             tipStream.lockedUntilEpoch >
@@ -149,22 +149,22 @@ contract TipJar is
     //////////////////////////////////////////////////////////////*/
 
     /// @inheritdoc ITipJar
-    function shake(address fleetCommander_) external whenNotPaused onlyKeeper {
+    function shake(address fleetCommander_) external whenNotPaused {
         _shake(fleetCommander_);
     }
 
     /// @inheritdoc ITipJar
-    function shakeMultiple(
-        address[] calldata fleetCommanders
-    ) external onlyKeeper {
+    function shakeMultiple(address[] calldata fleetCommanders) external {
         _shakeMultiple(fleetCommanders);
     }
 
     /// @notice Shakes all active fleet commanders
     /// @dev This function can be called to distribute rewards from all active fleet commanders
     /// @dev Warning: This operation can be gas expensive if there are many fleet commanders
-    function shakeAll() external onlyKeeper {
-        _shakeAll();
+    function shakeAll() public {
+        address[] memory activeFleetCommanders = IHarborCommand(harborCommand())
+            .getActiveFleetCommanders();
+        _shakeMultiple(activeFleetCommanders);
     }
 
     /**
@@ -308,16 +308,6 @@ contract TipJar is
         for (uint256 i = 0; i < fleetCommanders.length; i++) {
             _shake(fleetCommanders[i]);
         }
-    }
-
-    /**
-     * @notice Shakes all active fleet commanders
-     * @dev This function is used internally
-     */
-    function _shakeAll() internal {
-        address[] memory activeFleetCommanders = IHarborCommand(harborCommand())
-            .getActiveFleetCommanders();
-        _shakeMultiple(activeFleetCommanders);
     }
 
     /**

--- a/packages/core-contracts/test/fleets/FleetCommander.daoTipJar.integration.t.sol
+++ b/packages/core-contracts/test/fleets/FleetCommander.daoTipJar.integration.t.sol
@@ -75,16 +75,6 @@ contract DaoTipJarIntegrationTest is Test {
         );
 
         vm.startPrank(governor);
-        accessManager.grantContractSpecificRole(
-            ContractSpecificRoles.KEEPER_ROLE,
-            address(globalTipJar),
-            keeper
-        );
-        accessManager.grantContractSpecificRole(
-            ContractSpecificRoles.KEEPER_ROLE,
-            address(daoTipJar),
-            keeper
-        );
         configurationManager.initializeConfiguration(
             ConfigurationManagerParams({
                 raft: raft,
@@ -280,7 +270,6 @@ contract DaoTipJarIntegrationTest is Test {
         uint256 r2BeforeGlobal = underlying.balanceOf(streamRecipient2);
 
         vm.recordLogs();
-        vm.prank(keeper);
         globalTipJar.shakeAll();
         (
             uint256 globalNonDaoAmount,
@@ -312,7 +301,6 @@ contract DaoTipJarIntegrationTest is Test {
         uint256 r2BeforeDao = underlying.balanceOf(streamRecipient2);
 
         vm.recordLogs();
-        vm.prank(keeper);
         daoTipJar.shakeAll();
         (
             uint256 daoJarNonDaoAmount,

--- a/packages/core-contracts/test/fleets/TipJar.t.sol
+++ b/packages/core-contracts/test/fleets/TipJar.t.sol
@@ -40,6 +40,12 @@ contract TipJarTest is Test, ITipJarEvents {
 
     function setUp() public {
         accessManager = new ProtocolAccessManager(governor);
+        vm.prank(governor);
+        accessManager.grantContractSpecificRole(
+            ContractSpecificRoles.KEEPER_ROLE,
+            address(0),
+            keeper
+        );
         harborCommand = new HarborCommand(address(accessManager));
 
         underlyingToken = new ERC20Mock();
@@ -59,13 +65,6 @@ contract TipJarTest is Test, ITipJarEvents {
         );
 
         tipJar = new TipJar(address(accessManager), address(configManager));
-
-        vm.prank(governor);
-        accessManager.grantContractSpecificRole(
-            ContractSpecificRoles.KEEPER_ROLE,
-            address(tipJar),
-            keeper
-        );
         configManager.setTipRate(100); // 1%
 
         vm.prank(address(fleetCommander));
@@ -238,7 +237,6 @@ contract TipJarTest is Test, ITipJarEvents {
         vm.stopPrank();
 
         // Shake the jar
-        vm.prank(keeper);
         tipJar.shake(address(fleetCommander));
         assertEq(IERC20(fleetCommander).balanceOf(address(tipJar)), 0 ether);
         // Check balances
@@ -281,7 +279,6 @@ contract TipJarTest is Test, ITipJarEvents {
         vm.stopPrank();
 
         // Shake the jar
-        vm.prank(keeper);
         tipJar.shake(address(fleetCommander));
 
         // Check balances
@@ -338,7 +335,6 @@ contract TipJarTest is Test, ITipJarEvents {
         address[] memory commanders = new address[](2);
         commanders[0] = address(fleetCommander);
         commanders[1] = address(fleetCommander2);
-        vm.prank(keeper);
         tipJar.shakeMultiple(commanders);
 
         // Check balances (should be doubled compared to the single shake test)
@@ -387,7 +383,6 @@ contract TipJarTest is Test, ITipJarEvents {
         underlyingToken.mint(address(fleetCommander), accruedInterest);
 
         // Shake the jar
-        vm.prank(keeper);
         tipJar.shake(address(fleetCommander));
 
         // Calculate expected amounts
@@ -473,7 +468,6 @@ contract TipJarTest is Test, ITipJarEvents {
 
         vm.expectEmit(true, true, true, true);
         emit TipJarShaken(address(fleetCommander), 0);
-        vm.prank(keeper);
         tipJar.shake(address(fleetCommander));
     }
 
@@ -482,7 +476,6 @@ contract TipJarTest is Test, ITipJarEvents {
 
         vm.expectEmit(true, true, true, true);
         emit TipJarShaken(address(fleetCommander), 0);
-        vm.prank(keeper);
         tipJar.shake(address(fleetCommander));
     }
 
@@ -503,7 +496,6 @@ contract TipJarTest is Test, ITipJarEvents {
         vm.expectRevert(
             abi.encodeWithSignature("InvalidFleetCommanderAddress()")
         );
-        vm.prank(keeper);
         tipJar.shake(address(0));
     }
 
@@ -728,7 +720,6 @@ contract TipJarTest is Test, ITipJarEvents {
         vm.stopPrank();
 
         // Shake again to test new allocation
-        vm.prank(keeper);
         tipJar.shake(address(fleetCommander));
 
         // Check final balances
@@ -738,30 +729,5 @@ contract TipJarTest is Test, ITipJarEvents {
             900 ether
         ); // 600 + (30% of 1000)
         assertEq(underlyingToken.balanceOf(treasury), 200 ether); // Unchanged as 100% allocated to streams
-    }
-
-    function test_FailShakeWhenNotKeeper() public {
-        address nonKeeper = address(99);
-
-        vm.startPrank(nonKeeper);
-
-        vm.expectRevert(
-            abi.encodeWithSignature("CallerIsNotKeeper(address)", nonKeeper)
-        );
-        tipJar.shake(address(fleetCommander));
-
-        address[] memory commanders = new address[](1);
-        commanders[0] = address(fleetCommander);
-        vm.expectRevert(
-            abi.encodeWithSignature("CallerIsNotKeeper(address)", nonKeeper)
-        );
-        tipJar.shakeMultiple(commanders);
-
-        vm.expectRevert(
-            abi.encodeWithSignature("CallerIsNotKeeper(address)", nonKeeper)
-        );
-        tipJar.shakeAll();
-
-        vm.stopPrank();
     }
 }


### PR DESCRIPTION
reverts #790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reward distribution operations are now permissionless—all users can trigger distributions directly without requiring special keeper permissions, increasing protocol accessibility and participation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OasisDEX/summer-earn-protocol/pull/804)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->